### PR TITLE
Configure Typescript compilation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,10 @@
     "module": "commonjs",
     "outDir": "./dist",
     "rootDir": "./src",
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Configured `tsconfig.json` to properly compile Typescript code to Javascript in the `dist` folder.