### PR TITLE
ATM-170: Test Webhook Listing Endpoint Error Handling

### DIFF
--- a/tests/routes/webhookRoutes.test.ts
+++ b/tests/routes/webhookRoutes.test.ts
@@ -1,0 +1,20 @@
+// tests/routes/webhookRoutes.test.ts
+import request from 'supertest';
+import app from '../../src/app';
+import * as webhookService from '../../src/services/webhookService';
+
+describe('Webhook Listing Endpoint - Error Handling', () => {
+  it('should return 500 status and error message on internal server error', async () => {
+    // Mock the webhookService to throw an error
+    jest.spyOn(webhookService, 'listWebhooks').mockRejectedValue(new Error('Simulated internal server error'));
+
+    const response = await request(app).get('/api/webhooks');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toHaveProperty('message', 'Simulated internal server error');
+    // You might want to check for other error details depending on your application's error handling
+
+    // Restore the mock
+    (webhookService.listWebhooks as jest.Mock).mockRestore();
+  });
+});


### PR DESCRIPTION
This pull request adds a test case to verify the error handling of the webhook listing endpoint (GET /api/webhooks). It simulates an internal server error and checks for the correct error status code and response body.