### PR TITLE
feat(ATM-169): Add test for webhook listing endpoint with empty list

### DIFF
--- a/tests/routes/webhook_listing.test.ts
+++ b/tests/routes/webhook_listing.test.ts
@@ -1,0 +1,20 @@
+// tests/routes/webhook_listing.test.ts
+import request from 'supertest';
+import app from '../../src/app';
+
+describe('GET /api/webhooks - Empty List', () => {
+  it('should return a 200 OK status code', async () => {
+    const response = await request(app).get('/api/webhooks');
+    expect(response.status).toBe(200);
+  });
+
+  it('should return a JSON array', async () => {
+    const response = await request(app).get('/api/webhooks');
+    expect(response.headers['content-type']).toEqual(expect.stringContaining('application/json'));
+  });
+
+  it('should return an empty array', async () => {
+    const response = await request(app).get('/api/webhooks');
+    expect(response.body).toEqual([]);
+  });
+});


### PR DESCRIPTION
This pull request adds tests for the webhook listing endpoint (GET /api/webhooks) to verify its behavior when no webhooks are registered.  The tests cover the following scenarios:

- Ensure the endpoint returns a 200 OK status code.
- Verify the response body is a JSON array.
- Confirm the array is empty.