### PR TITLE
Test Case: Verify Webhook Trigger on Issue Deletion

### DIFF
--- a/tests/routes/issueDelete.test.ts
+++ b/tests/routes/issueDelete.test.ts
@@ -1,0 +1,83 @@
+// tests/routes/issueDelete.test.ts
+
+import request from 'supertest';
+import app from '../../src/app';
+import { createIssue, deleteIssue } from '../utils/issueHelper'; // Assuming you have helper functions
+import { createWebhook, deleteWebhook } from '../utils/webhookHelper';
+
+
+// Mock the webhookService to prevent actual webhook calls
+jest.mock('../../src/services/webhookService', () => ({
+    sendWebhook: jest.fn().mockResolvedValue(true),
+}));
+
+const mockSendWebhook = require('../../src/services/webhookService').sendWebhook;
+
+describe('Issue Deletion Webhook Trigger', () => {
+    let issueKey: string;
+    let webhookUrl: string;
+    let webhookId: string;
+
+    beforeEach(async () => {
+        // Create a webhook
+        webhookUrl = 'http://example.com/webhook';
+        const webhookResponse = await createWebhook(webhookUrl, 'issue.deleted');
+        webhookId = webhookResponse.id;
+    });
+
+    afterEach(async () => {
+        // Delete the issue if it was created
+        if (issueKey) {
+            await deleteIssue(issueKey);
+        }
+
+        // Delete the webhook
+        if (webhookId) {
+            await deleteWebhook(webhookId);
+        }
+        jest.clearAllMocks();
+    });
+
+    it('should trigger a webhook when an issue is deleted', async () => {
+        // 1. Create a new issue
+        const issueData = {
+            fields: {
+                summary: 'Test Issue for Webhook',
+                issuetype: { name: 'Task' },
+            },
+        };
+
+        const createdIssue = await createIssue(issueData);
+        issueKey = createdIssue.key;
+
+        // 2. Delete the created issue
+        await deleteIssue(issueKey);
+
+        // 3. Verify that a webhook was sent
+        expect(mockSendWebhook).toHaveBeenCalled();
+        expect(mockSendWebhook).toHaveBeenCalledWith(webhookUrl, expect.objectContaining({
+            event: 'issue.deleted',
+            issue: expect.objectContaining({ key: issueKey }), // Verify issue key in the payload
+        }));
+
+    });
+
+    it('should not trigger a webhook if no webhook is registered', async () => {
+         // 1. Create a new issue
+         const issueData = {
+            fields: {
+                summary: 'Test Issue for Webhook',
+                issuetype: { name: 'Task' },
+            },
+        };
+
+        const createdIssue = await createIssue(issueData);
+        issueKey = createdIssue.key;
+
+        // 2. Delete the created issue
+        await deleteIssue(issueKey);
+
+         // 3. Verify that a webhook was sent
+        expect(mockSendWebhook).not.toHaveBeenCalled();
+    });
+});

--- a/tests/utils/issueHelper.ts
+++ b/tests/utils/issueHelper.ts
@@ -1,0 +1,19 @@
+// tests/utils/issueHelper.ts
+import request from 'supertest';
+import app from '../../src/app';
+
+export async function createIssue(issueData: any) {
+    const response = await request(app)
+        .post('/api/issue')
+        .send(issueData)
+        .set('Accept', 'application/json')
+        .expect(201);
+    return response.body;
+}
+
+export async function deleteIssue(issueKey: string) {
+    await request(app)
+        .delete(`/api/issue/${issueKey}`)
+        .set('Accept', 'application/json')
+        .expect(204);
+}

--- a/tests/utils/webhookHelper.ts
+++ b/tests/utils/webhookHelper.ts
@@ -1,0 +1,19 @@
+// tests/utils/webhookHelper.ts
+import request from 'supertest';
+import app from '../../src/app';
+
+export async function createWebhook(url: string, event: string) {
+  const response = await request(app)
+    .post('/api/webhook')
+    .send({ url, event })
+    .set('Accept', 'application/json')
+    .expect(201);
+  return response.body;
+}
+
+export async function deleteWebhook(webhookId: string) {
+  await request(app)
+    .delete(`/api/webhook/${webhookId}`)
+    .set('Accept', 'application/json')
+    .expect(204);
+}


### PR DESCRIPTION
This pull request adds a test case to verify that a webhook is triggered when an issue is deleted.  The test creates an issue, deletes it, and then checks if a webhook call was made and that the payload contains the correct data.