### PR TITLE
Fix: CI/CD Pipeline - Dependency Installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
This pull request addresses the issue where the CI/CD pipeline was failing due to missing dependencies, specifically 'vitest'. The fix involves adding a GitHub Actions workflow file (.github/workflows/ci.yml) that installs project dependencies using `npm install` before running tests. This ensures that all required packages, including 'vitest', are available during the test execution.