### PR TITLE
Implement GET /issue/{issueNumber} endpoint

### DIFF
--- a/src/controllers/issueController.ts
+++ b/src/controllers/issueController.ts
@@ -1,0 +1,24 @@
+// src/controllers/issueController.ts
+import { Request, Response } from 'express';
+import { getIssueService } from '../services/issueService';
+
+export async function getIssue(req: Request, res: Response) {
+  const issueNumber = req.params.issueNumber;
+  const fieldsParam = req.query.fields as string | undefined;
+
+  try {
+    const issue = await getIssueService(issueNumber, fieldsParam);
+
+    if (!issue) {
+      return res.status(404).json({ message: 'Issue not found' });
+    }
+
+    res.status(200).json(issue);
+  } catch (error: any) {
+    if (error.message === 'Invalid issue number format') {
+      return res.status(400).json({ message: 'Bad Request: Invalid issue number format' });
+    }
+    console.error(error);
+    res.status(500).json({ message: 'Internal Server Error' });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,13 @@
+// src/index.ts
+import express from 'express';
+import routes from './routes';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use('/', routes);
+
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,9 @@
+// src/routes/index.ts
+import express from 'express';
+import { getIssue } from '../controllers/issueController';
+
+const router = express.Router();
+
+router.get('/issue/:issueNumber', getIssue);
+
+export default router;

--- a/src/services/issueService.ts
+++ b/src/services/issueService.ts
@@ -1,0 +1,77 @@
+// src/services/issueService.ts
+
+// In-memory data (replace with database in a real application)
+const issues = [
+  {
+    id: '1',
+    key: 'TASK-1',
+    properties: {},
+    fields: {
+      issuetype: { id: '1', description: 'Task', name: 'Task', subtask: false, hierarchyLevel: 0 },
+      project: { id: '1', key: 'TASK', name: 'Task Project' },
+      priority: { name: 'High', id: '1' },
+      labels: ['backend', 'api'],
+      issuelinks: [],
+      status: { name: 'Open', id: '1' },
+      description: 'Implement GET /issue/{issueNumber}',
+      summary: 'Implement API Endpoint: GET /issue/{issueNumber} (Find Issue)',
+      subtasks: [],
+      progress: { progress: 50, total: 100 },
+    },
+  },
+  {
+    id: '2',
+    key: 'BUG-1',
+    properties: {},
+    fields: {
+      issuetype: { id: '2', description: 'Bug', name: 'Bug', subtask: false, hierarchyLevel: 0 },
+      project: { id: '2', key: 'BUG', name: 'Bug Project' },
+      priority: { name: 'High', id: '1' },
+      labels: ['frontend', 'ui'],
+      issuelinks: [],
+      status: { name: 'Open', id: '1' },
+      description: 'Fix button alignment issue',
+      summary: 'Button alignment issue',
+      subtasks: [],
+      progress: { progress: 100, total: 100 },
+    },
+  },
+];
+
+function parseIssueNumber(issueNumber: string): { projectKey: string, issueId: string } | null {
+    const match = issueNumber.match(/^([A-Z]+)-(\d+)$/);
+    if (!match) {
+        return null;
+    }
+    return {
+        projectKey: match[1],
+        issueId: match[2]
+    };
+}
+
+export async function getIssueService(issueNumber: string, fieldsParam?: string) {
+  const parsedIssueNumber = parseIssueNumber(issueNumber);
+  if (!parsedIssueNumber) {
+    throw new Error('Invalid issue number format');
+  }
+
+  const issue = issues.find((issue) => issue.key === issueNumber);
+
+  if (!issue) {
+    return null;
+  }
+
+  if (fieldsParam) {
+    const fieldsToReturn = fieldsParam.split(',');
+    const filteredIssue: any = { ...issue }; // Create a copy to avoid modifying the original
+    filteredIssue.fields = {};
+    for (const field of fieldsToReturn) {
+        if (issue.fields && issue.fields[field as keyof typeof issue.fields]) {
+            filteredIssue.fields[field] = issue.fields[field as keyof typeof issue.fields];
+        }
+    }
+    return filteredIssue;
+  }
+
+  return issue;
+}


### PR DESCRIPTION
This pull request implements the GET /issue/{issueNumber} API endpoint, as described in ATM-297. It includes:

- Controller and service functions for handling the request.
- In-memory data retrieval.
- Field selection using the `fields` query parameter.
- Error handling for 'Issue Not Found' and 'Bad Request' scenarios.