### PR TITLE
Implement Integration Tests for API Endpoints

### DIFF
--- a/src/tests/routes/issue.routes.test.ts
+++ b/src/tests/routes/issue.routes.test.ts
@@ -1,0 +1,67 @@
+// src/tests/routes/issue.routes.test.ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { app } from '../../index'; // Assuming you have an app instance
+import { InMemoryStorage } from '../../data/inMemoryStorage';
+import { DataService } from '../../services/dataService';
+import { IssueService } from '../../services/issueService';
+
+const dataService = new DataService(new InMemoryStorage());
+const issueService = new IssueService(dataService);
+
+describe('Issue Routes Integration Tests', () => {
+  beforeAll(async () => {
+    // Seed in-memory data if needed
+    await issueService.createIssue({ summary: 'Test Issue', description: 'Test Description', assignee: 'testuser' });
+  });
+
+  afterAll(async () => {
+    // Clean up in-memory data if needed
+    dataService.clear();
+  });
+
+  it('GET /api/issues should return a list of issues', async () => {
+    const res = await request(app).get('/api/issues');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('POST /api/issues should create a new issue', async () => {
+    const newIssue = {
+      summary: 'New Test Issue',
+      description: 'New Test Description',
+      assignee: 'anotheruser',
+    };
+    const res = await request(app).post('/api/issues').send(newIssue);
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toHaveProperty('id');
+    expect(res.body.summary).toBe(newIssue.summary);
+  });
+
+  it('GET /api/issues/:id should return a specific issue', async () => {
+    const allIssues = await request(app).get('/api/issues');
+    const issueId = allIssues.body[0].id;
+    const res = await request(app).get(`/api/issues/${issueId}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('id');
+  });
+
+  it('PUT /api/issues/:id should update an issue', async () => {
+    const allIssues = await request(app).get('/api/issues');
+    const issueId = allIssues.body[0].id;
+    const updatedIssue = { summary: 'Updated Test Issue' };
+    const res = await request(app).put(`/api/issues/${issueId}`).send(updatedIssue);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.summary).toBe(updatedIssue.summary);
+  });
+
+  it('DELETE /api/issues/:id should delete an issue', async () => {
+    const allIssues = await request(app).get('/api/issues');
+    const issueId = allIssues.body[0].id;
+    const res = await request(app).delete(`/api/issues/${issueId}`);
+    expect(res.statusCode).toBe(204);
+    // Verify that the issue is actually deleted (optional)
+    const getRes = await request(app).get(`/api/issues/${issueId}`);
+    expect(getRes.statusCode).toBe(404);
+  });
+});

--- a/src/tests/routes/webhook.routes.test.ts
+++ b/src/tests/routes/webhook.routes.test.ts
@@ -1,0 +1,57 @@
+// src/tests/routes/webhook.routes.test.ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { app } from '../../index'; // Assuming you have an app instance
+import { InMemoryStorage } from '../../data/inMemoryStorage';
+import { DataService } from '../../services/dataService';
+import { WebhookService } from '../../services/webhookService';
+
+const dataService = new DataService(new InMemoryStorage());
+const webhookService = new WebhookService(dataService);
+
+describe('Webhook Routes Integration Tests', () => {
+  beforeAll(async () => {
+    // Seed in-memory data if needed
+  });
+
+  afterAll(async () => {
+    // Clean up in-memory data if needed
+    dataService.clear();
+  });
+
+  it('POST /api/webhooks should register a webhook', async () => {
+    const webhookData = {
+      url: 'https://example.com/webhook',
+      events: ['issue_created'],
+    };
+    const res = await request(app).post('/api/webhooks').send(webhookData);
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toHaveProperty('id');
+    // Add more assertions based on the expected response
+  });
+
+  it('GET /api/webhooks should list registered webhooks', async () => {
+    const res = await request(app).get('/api/webhooks');
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    // Add more assertions based on the expected response
+  });
+
+  it('DELETE /api/webhooks/:id should delete a webhook', async () => {
+    // First, register a webhook
+    const webhookData = {
+      url: 'https://example.com/webhook-delete',
+      events: ['issue_created'],
+    };
+    const registerRes = await request(app).post('/api/webhooks').send(webhookData);
+    const webhookId = registerRes.body.id;
+
+    const res = await request(app).delete(`/api/webhooks/${webhookId}`);
+    expect(res.statusCode).toBe(204);
+
+    // Verify that the webhook is actually deleted (optional)
+    const getRes = await request(app).get('/api/webhooks');
+    const webhookExists = getRes.body.some((webhook) => webhook.id === webhookId);
+    expect(webhookExists).toBe(false);
+  });
+});


### PR DESCRIPTION
This pull request implements integration tests for the API endpoints, including routes for issues and webhooks. The tests cover request handling, response status codes, and response body schemas, and aim for 80% code coverage.