### PR TITLE
Refactor: Use dataService for issue linking and validation

### DIFF
--- a/src/data/dataService.ts
+++ b/src/data/dataService.ts
@@ -1,0 +1,56 @@
+// src/services/dataService.ts
+import { issues, Issue } from './inMemoryStorage';
+
+export const createIssue = (issue: Issue): Issue => {
+  issue.id = Math.random().toString(); // Simple ID generation
+  issues.push(issue);
+  return issue;
+};
+
+export const getIssueByKey = (key: string): Issue | undefined => {
+  return issues.find(issue => issue.key === key);
+};
+
+export const getAllIssues = (): Issue[] => {
+  return issues;
+};
+
+export const updateIssue = (key: string, updatedFields: Partial<Issue>): Issue | undefined => {
+    const issueIndex = issues.findIndex(issue => issue.key === key);
+    if (issueIndex === -1) {
+        return undefined;
+    }
+    issues[issueIndex] = { ...issues[issueIndex], ...updatedFields };
+    return issues[issueIndex];
+}
+
+export const deleteIssue = (key: string): boolean => {
+  const initialLength = issues.length;
+  issues = issues.filter(issue => issue.key !== key);
+  return issues.length !== initialLength;
+};
+
+export const linkIssues = (inwardKey: string, outwardKey: string): void => {
+  const inwardIssue = issues.find(issue => issue.key === inwardKey);
+  const outwardIssue = issues.find(issue => issue.key === outwardKey);
+
+  if (!inwardIssue || !outwardIssue) {
+    throw new Error('Issue not found');
+  }
+
+  if (!inwardIssue.linkedIssues) {
+    inwardIssue.linkedIssues = [];
+  }
+  if (!inwardIssue.linkedIssues.includes(outwardKey)) {
+    inwardIssue.linkedIssues.push(outwardKey);
+  }
+
+  if (outwardIssue) {
+    if (!outwardIssue.linkedIssues) {
+      outwardIssue.linkedIssues = [];
+    }
+    if (!outwardIssue.linkedIssues.includes(inwardKey)) {
+      outwardIssue.linkedIssues.push(inwardKey);
+    }
+  }
+};

--- a/src/data/inMemoryStorage.ts
+++ b/src/data/inMemoryStorage.ts
@@ -33,25 +33,3 @@ export interface Webhook {
 export const issues: Issue[] = [];
 export const boards: Board[] = [];
 export const webhooks: Webhook[] = [];
-
-export const addIssueLink = (inwardKey: string, outwardKey: string) => {
-  const inwardIssue = issues.find(issue => issue.key === inwardKey);
-  const outwardIssue = issues.find(issue => issue.key === outwardKey);
-
-  if (inwardIssue) {
-    if (!inwardIssue.linkedIssues) {
-      inwardIssue.linkedIssues = [];
-    }
-    if (!inwardIssue.linkedIssues.includes(outwardKey)) {
-      inwardIssue.linkedIssues.push(outwardKey);
-    }
-  }
-  if (outwardIssue) {
-    if (!outwardIssue.linkedIssues) {
-      outwardIssue.linkedIssues = [];
-    }
-    if (!outwardIssue.linkedIssues.includes(inwardKey)) {
-      outwardIssue.linkedIssues.push(inwardKey);
-    }
-  }
-};

--- a/src/services/issueService.ts
+++ b/src/services/issueService.ts
@@ -28,12 +28,5 @@ export const linkIssues = async (inwardKey: string, outwardKey: string): Promise
         throw new Error('Invalid issue keys');
     }
 
-    const inwardIssue = dataService.getIssueByKey(inwardKey);
-    const outwardIssue = dataService.getIssueByKey(outwardKey);
-
-    if (!inwardIssue || !outwardIssue) {
-        throw new Error('Issue not found');
-    }
-
-    dataService.addIssueLink(inwardKey, outwardKey);
+    dataService.linkIssues(inwardKey, outwardKey);
 };


### PR DESCRIPTION
This pull request refactors the issue linking implementation to use a dataService and includes validation. This improves the separation of concerns and makes testing easier.

**Changes:**
- Refactored `src/services/issueService.ts` to use dataService for linking issues.
- Created `src/data/dataService.ts` to handle data operations, including issue linking and validation.
- Cleaned up `src/data/inMemoryStorage.ts`.
