### PR TITLE
feat(ATM-321): Verify project initialization (package.json)

### DIFF
--- a/src/tests/projectInitialization.test.ts
+++ b/src/tests/projectInitialization.test.ts
@@ -1,19 +1,32 @@
 // src/tests/projectInitialization.test.ts
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
-import { describe, it, expect } from 'vitest';
+import { expect, it, describe } from 'vitest';
 
-const packageJsonPath = resolve(__dirname, '../package.json');
+describe('package.json verification', () => {
+  it('should exist', () => {
+    const packageJsonPath = resolve(__dirname, '../package.json');
+    expect(existsSync(packageJsonPath)).toBe(true);
+  });
 
-describe('Package.json Dependencies', () => {
-  it('should include express, @types/express, body-parser, and uuid as dependencies', () => {
+  it('should contain the correct scripts', () => {
+    const packageJsonPath = resolve(__dirname, '../package.json');
+    const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    expect(packageJson.scripts).toBeDefined();
+    expect(packageJson.scripts.start).toBe('node dist/index.js');
+    expect(packageJson.scripts.dev).toBe('ts-node-dev src/index.ts');
+  });
+
+  it('should contain the necessary dependencies', () => {
+    const packageJsonPath = resolve(__dirname, '../package.json');
     const packageJsonContent = readFileSync(packageJsonPath, 'utf-8');
     const packageJson = JSON.parse(packageJsonContent);
 
     expect(packageJson.dependencies).toBeDefined();
-    expect(packageJson.dependencies).toHaveProperty('express');
-    expect(packageJson.dependencies).toHaveProperty('@types/express');
-    expect(packageJson.dependencies).toHaveProperty('body-parser');
-    expect(packageJson.dependencies).toHaveProperty('uuid');
+    expect(packageJson.devDependencies).toBeDefined();
+    expect(Object.keys(packageJson.dependencies).some(dep => dep === 'express')).toBe(true);
+    expect(Object.keys(packageJson.devDependencies).some(dep => dep === 'typescript')).toBe(true);
   });
 });


### PR DESCRIPTION
This pull request implements the test case to verify the successful creation and content of the `package.json` file, ensuring it contains the necessary fields and scripts. The tests have been written to check for the existence of the file, the presence of specific scripts (`start`, `dev`), and the required dependencies (typescript, express, etc.).