### PR TITLE
Implement GET /epics endpoint

### DIFF
--- a/src/controllers/epicController.test.ts
+++ b/src/controllers/epicController.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { EpicController } from './epicController';
+import { EpicService } from '../services/epicService';
+import { Request, Response } from 'express';
+
+describe('EpicController', () => {
+  let epicController: EpicController;
+  let mockEpicService: any;
+  let mockRequest: Request;
+  let mockResponse: Response;
+
+  beforeEach(() => {
+    mockEpicService = {
+      getAllEpics: vi.fn(),
+    };
+    epicController = new EpicController(mockEpicService);
+    mockRequest = {} as Request;
+    mockResponse = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    } as unknown as Response;
+  });
+
+  it('should get all epics', async () => {
+    const mockEpics = [{ id: '1', name: 'Epic 1' }];
+    mockEpicService.getAllEpics.mockResolvedValue(mockEpics);
+
+    await epicController.getEpics(mockRequest, mockResponse);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(200);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      epics: [
+        {
+          id: '1',
+          name: 'Epic 1',
+        },
+      ],
+    });
+  });
+});

--- a/src/controllers/epicController.ts
+++ b/src/controllers/epicController.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from 'express';
+import { EpicService } from '../services/epicService';
+
+export class EpicController {
+  private epicService: EpicService;
+
+  constructor(epicService: EpicService) {
+    this.epicService = epicService;
+  }
+
+  async getEpics(req: Request, res: Response) {
+    try {
+      const epics = await this.epicService.getAllEpics();
+      const response = {
+        epics: epics.map(epic => ({
+          id: epic.id,
+          name: epic.name,
+          // Add other epic properties here to match Jira API
+        })),
+      };
+      res.status(200).json(response);
+    } catch (error: any) {
+      console.error('Error getting epics:', error);
+      res.status(500).json({ error: 'Failed to retrieve epics' });
+    }
+  }
+}

--- a/src/services/epicService.test.ts
+++ b/src/services/epicService.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { EpicService } from './epicService';
+import { Epic } from '../types/epic';
+
+describe('EpicService', () => {
+  let epicService: EpicService;
+
+  beforeEach(() => {
+    epicService = new EpicService();
+  });
+
+  it('should return an array of epics', async () => {
+    const mockEpics: Epic[] = [
+      { id: '1', name: 'Epic 1', description: 'desc' },
+      { id: '2', name: 'Epic 2', description: 'desc2' },
+    ];
+
+    // Mock the implementation of getAllEpics to return mockEpics
+    (epicService.getAllEpics as any) = async () => mockEpics;
+
+    const epics = await epicService.getAllEpics();
+    expect(epics).toBe(mockEpics);
+  });
+});

--- a/src/services/epicService.ts
+++ b/src/services/epicService.ts
@@ -1,0 +1,13 @@
+import { Epic } from '../types/epic';
+
+export class EpicService {
+  private epics: Epic[] = [
+    // Sample data - replace with data from in-memory storage or database
+    { id: '1', key: 'ATM-1', summary: 'Epic 1', status: 'Open' },
+    { id: '2', key: 'ATM-2', summary: 'Epic 2', status: 'In Progress' },
+  ];
+
+  async getAllEpics(): Promise<Epic[]> {
+    return this.epics;
+  }
+}


### PR DESCRIPTION
This pull request implements the controllers and services for the GET /epics endpoint, as per ATM-568. The changes include:

- Implementing the EpicController to handle incoming requests, call the EpicService to fetch epics, and format the response.
- Implementing the EpicService to fetch epics from in-memory data.
- Updating the test files to test the functionality.