### PR TITLE
feat(ATM-557): Implement in-memory data storage for boards and issues

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,71 @@
+import express from 'express';
+import boardRoutes from './routes/boardRoutes';
+
+const app = express();
+
+// Middleware to parse JSON request bodies
+app.use(express.json()); 
+
+// In-memory data storage
+let boards: any[] = []; // Assuming Board and Issue interfaces are defined in types.ts
+let issues: any[] = [];
+
+// Route to create a new board (example)
+app.post('/boards', (req, res) => {
+    const newBoard = {
+        id: Date.now(), // Simple ID generation, consider UUIDs for production
+        name: req.body.name,
+        statuses: req.body.statuses || [],
+        issueIds: []
+    };
+    boards.push(newBoard);
+    res.status(201).json(newBoard);
+});
+
+// Route to get all boards
+app.get('/boards', (req, res) => {
+    res.json(boards);
+});
+
+// Route to create an issue and associate it with a board
+app.post('/issues', (req, res) => {
+    const { summary, description, boardId } = req.body;
+    const newIssue = {
+        id: Date.now(),
+        summary,
+        description,
+        boardId: boardId || null // Allow issues without a board
+    };
+    issues.push(newIssue);
+
+    // Associate issue with board
+    if (boardId) {
+        const board = boards.find(b => b.id === boardId);
+        if (board) {
+            board.issueIds.push(newIssue.id);
+        }
+    }
+    res.status(201).json(newIssue);
+});
+
+// Route to get all issues
+app.get('/issues', (req, res) => {
+    res.json(issues);
+});
+
+// Route to get issues for a specific board
+app.get('/boards/:boardId/issues', (req, res) => {
+    const boardId = parseInt(req.params.boardId, 10);
+    const board = boards.find(b => b.id === boardId);
+    if (!board) {
+        return res.status(404).json({ message: 'Board not found' });
+    }
+
+    const boardIssueIds = board.issueIds;
+    const boardIssues = issues.filter(issue => boardIssueIds.includes(issue.id));
+    res.json(boardIssues);
+});
+
+app.use('/', boardRoutes);
+
+export default app;

--- a/src/routes/boardRoutes.test.ts
+++ b/src/routes/boardRoutes.test.ts
@@ -1,0 +1,64 @@
+import request from 'supertest';
+import app from '../app';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+// Helper function to create a board
+const createBoard = async (name: string) => {
+    const res = await request(app).post('/boards').send({ name });
+    return res.body;
+};
+
+// Helper function to create an issue
+const createIssue = async (summary: string, description: string, boardId: number | null) => {
+    const res = await request(app).post('/issues').send({ summary, description, boardId });
+    return res.body;
+};
+
+describe('GET /boards/:boardId/issues', () => {
+    let board1: any;
+    let board2: any;
+    let issue1: any;
+    let issue2: any;
+
+    beforeAll(async () => {
+        // Create some boards and issues before running tests
+        board1 = await createBoard('Board 1');
+        board2 = await createBoard('Board 2');
+        issue1 = await createIssue('Issue 1', 'Description 1', board1.id);
+        issue2 = await createIssue('Issue 2', 'Description 2', board1.id);
+    });
+
+    afterAll(async () => {
+      // Clean up:  reset the in-memory data to avoid polluting future tests
+      // This is a basic approach for an in-memory store, in a real app
+      // you'd likely have a separate test setup for managing the state.
+      // Here, we're just clearing the data to keep tests independent.
+      // In a real-world scenario, you'd have a way to seed and teardown your database
+      // before and after the tests to have a clean state.
+      // For simplicity and given the in-memory nature, just clear the data here.
+      // @ts-ignore
+      app.boards = [];
+      // @ts-ignore
+      app.issues = [];
+    });
+
+    it('should return 200 OK and issues for a valid boardId', async () => {
+        const res = await request(app).get(`/boards/${board1.id}/issues`);
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toBeInstanceOf(Array);
+        expect(res.body.length).toBe(2);
+        expect(res.body[0].summary).toBe('Issue 1');
+        expect(res.body[1].summary).toBe('Issue 2');
+    });
+
+    it('should return an empty array for a boardId with no issues', async () => {
+        const res = await request(app).get(`/boards/${board2.id}/issues`);
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual([]);
+    });
+
+    it('should return 404 Not Found if boardId does not exist', async () => {
+        const res = await request(app).get('/boards/999/issues'); // Nonexistent board
+        expect(res.statusCode).toBe(404);
+    });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,19 @@
+export interface Board {
+  id: string | number;
+  name: string;
+  statuses: BoardStatus[];
+  issueIds: (string | number)[];
+}
+
+export interface BoardStatus {
+  id: string | number;
+  name: string;
+  category: 'open' | 'indeterminate' | 'done';
+}
+
+export interface Issue {
+  id: string | number;
+  summary: string;
+  description: string;
+  boardId: string | number | null;
+}


### PR DESCRIPTION
This commit implements in-memory data structures (arrays) to store board and issue data. It also includes routes for creating boards and issues, and associating issues with boards.  

Key changes:
- Added `boards` and `issues` arrays to `app.ts` for in-memory storage.
- Implemented POST routes for `/boards` and `/issues`.
- Implemented a GET route for `/boards/:boardId/issues` to retrieve issues associated with a board.
- Updated `src/types.ts` to include `issueIds` in the `Board` interface.
- Added tests in `src/routes/boardRoutes.test.ts` to verify the functionality.