### PR TITLE
Define Board and BoardStatus Typescript interfaces

### DIFF
--- a/src/board.ts
+++ b/src/board.ts
@@ -1,0 +1,17 @@
+export interface Board {
+  id: string | number;
+  name: string;
+  statuses: BoardStatus[];
+}
+
+export enum BoardStatusCategory {
+  open = 'open',
+  indeterminate = 'indeterminate',
+  done = 'done',
+}
+
+export interface BoardStatus {
+  id: string | number;
+  name: string;
+  category: BoardStatusCategory;
+}


### PR DESCRIPTION
This pull request defines the Typescript interfaces for `Board` and `BoardStatus` as per the requirements of issue ATM-555.

**Changes:**
- Created `src/board.ts` with the following interfaces:
  - `Board`: `id`, `name`, `statuses`
  - `BoardStatus`: `id`, `name`, `category` (using an enum for category)

These interfaces align with the technical design document.