### PR TITLE
ATM-996: Define request and response formats for webhook API endpoints

### DIFF
--- a/src/types/webhook.d.ts
+++ b/src/types/webhook.d.ts
@@ -37,3 +37,21 @@ export interface WebhookService {
   deleteWebhook(webhookId: string): Promise<WebhookDeleteResponse>;
   listWebhooks(): Promise<WebhookListResponse>;
 }
+
+// Define request and response types for the API endpoints
+
+// POST /api/webhooks (Register)
+export interface RegisterWebhookRequest extends WebhookRegisterRequest {}
+
+export interface RegisterWebhookResponse extends WebhookRegisterResponse {}
+
+// DELETE /api/webhooks/:webhookId (Delete)
+export interface DeleteWebhookResponse {
+  id: string;
+  status: string;
+}
+
+// GET /api/webhooks (List)
+export interface ListWebhooksResponse {
+  webhooks: Webhook[];
+}


### PR DESCRIPTION
Defined request and response formats for webhook API endpoints as per ATM-996. This includes defining the JSON schema for the register, delete, and list webhook endpoints.