### PR TITLE
ATM-996: Define request and response formats for webhook API endpoints

### DIFF
--- a/src/types/webhook.d.ts
+++ b/src/types/webhook.d.ts
@@ -67,3 +67,21 @@ export interface ListWebhooksRequest {
 export interface ListWebhooksResponse {
   webhooks: Webhook[];
 }
+
+// Additional types for improved type safety and clarity
+
+export enum WebhookStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  DELETED = 'deleted',
+}
+
+export interface WebhookEvent {
+  name: string;
+  description?: string;
+}
+
+//  Extend Webhook interface with additional fields or specific types as needed.  Example:
+//  export interface Webhook extends Webhook {
+//    createdBy: string;
+//  }


### PR DESCRIPTION
Defines the request and response formats for the webhook API endpoints, adhering to the specifications outlined in ATM-996.