### PR TITLE
ATM-996: Define request and response formats for webhook API endpoints

### DIFF
--- a/src/types/webhook.d.ts
+++ b/src/types/webhook.d.ts
@@ -3,7 +3,41 @@
 export interface WebhookRegistration {
   url: string;
   events: string[];
+  secret?: string; // Optional secret for verification
   // Add other registration parameters as needed
+}
+
+export interface Webhook {
+  id: string;
+  url: string;
+  events: string[];
+  secret?: string; // Stored secret
+  // Add other webhook properties as needed
+}
+
+export interface WebhookRegisterRequest {
+  url: string;
+  events: string[];
+  secret?: string;
+}
+
+export interface WebhookRegisterResponse {
+  id: string;
+  url: string;
+  events: string[];
+  secret?: string;
+  status: string; // e.g., 'active', 'inactive'
+}
+
+export interface WebhookDeleteResponse {
+  message: string;
+  webhookId: string;
+  success: boolean;
+}
+
+export interface WebhookListResponse {
+  webhooks: Webhook[];
+  total: number;
 }
 
 export interface WebhookPayload {
@@ -11,11 +45,4 @@ export interface WebhookPayload {
   data: any;    // Example:  Details of the event (e.g., issue details)
   timestamp: string;
   webhookId: string;
-}
-
-export interface Webhook {
-  id: string;
-  url: string;
-  events: string[];
-  // Add other webhook properties as needed
 }


### PR DESCRIPTION
Defined request and response formats for webhook API endpoints as requested in ATM-996. This includes the JSON schema for Register, Delete, and List operations. The types have been defined to align with the issue requirements.