### PR TITLE
ATM-994: Epic 4: API Endpoints - Webhooks

### DIFF
--- a/src/api/controllers/webhook.controller.ts
+++ b/src/api/controllers/webhook.controller.ts
@@ -45,5 +45,19 @@ export class WebhookController {
       res.status(500).json({ message: error.message });
     }
   }
-  // Add a method to handle retrieving a single webhook if needed
+
+  async getWebhookById(req: Request, res: Response) {
+    try {
+      const webhookId = req.params.id;
+      const webhook = await this.webhookService.getWebhookById(webhookId);
+      if (webhook) {
+        res.status(200).json(webhook);
+      } else {
+        res.status(404).json({ message: 'Webhook not found' });
+      }
+    } catch (error: any) {
+      console.error('Error getting webhook by id:', error);
+      res.status(500).json({ message: error.message });
+    }
+  }
 }

--- a/src/api/routes/webhook.routes.ts
+++ b/src/api/routes/webhook.routes.ts
@@ -8,6 +8,7 @@ export function createWebhookRoutes(controller: WebhookController): Router {
   router.post('/webhooks', controller.registerWebhook);
   router.delete('/webhooks/:id', controller.deleteWebhook);
   router.get('/webhooks', controller.listWebhooks);
+  router.get('/webhooks/:id', controller.getWebhookById);
 
   return router;
 }


### PR DESCRIPTION
This pull request implements the API endpoints for webhook-related operations, as defined in ATM-994. It includes the following changes:

- Added `getWebhookById` method to the `WebhookController` to retrieve a single webhook by ID.
- Added corresponding route in `webhook.routes.ts` for `getWebhookById`.
- Implemented the `getWebhookById` method in the `WebhookService` to fetch webhook information from the database.
- Updated the `generateSignature` function in `WebhookService` to use the `crypto` module for HMAC-SHA256 signature generation, removing the placeholder and providing a secure implementation.