### PR TITLE
ATM-1042: Write unit tests for webhook API controllers and services

### DIFF
--- a/src/api/controllers/webhook.controller.test.ts
+++ b/src/api/controllers/webhook.controller.test.ts
@@ -2,73 +2,123 @@
 import { test, describe, expect, beforeEach, vi } from 'vitest';
 import request from 'supertest';
 import app from '../../app'; // Import the app instance
-import * as webhookService from '../services/webhook.service';
+import { WebhookService } from '../services/webhook.service';
+import { validateWebhookRegister } from '../middleware/webhookValidation';
+import { Request, Response } from 'express';
+import { mock } from 'vitest-mock-extended';
+import { validationResult } from 'express-validator';
+
+vi.mock('../services/webhook.service');
+vi.mock('../middleware/webhookValidation');
+
+const mockWebhookService = mock<WebhookService>();
 
 describe('Webhook Controller', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(WebhookService).mockReturnValue(mockWebhookService);
+    (validateWebhookRegister as jest.Mock).mockImplementation((req: Request, res: Response, next: () => void) => {
+      next();
+    });
   });
 
   describe('POST /api/webhooks', () => {
     it('should register a webhook successfully', async () => {
-      const mockCreateWebhook = vi.spyOn(webhookService, 'createWebhook').mockResolvedValue({ id: '123', url: 'https://example.com' });
-      const response = await request(app).post('/api/webhooks').send({ url: 'https://example.com' });
+      const registerWebhookMock = vi.spyOn(mockWebhookService, 'registerWebhook').mockResolvedValue({ id: '123', url: 'https://example.com', events: [], secret: '', status: 'active' });
+      const response = await request(app).post('/api/webhooks').send({ url: 'https://example.com', events: [], secret: 'secret' });
 
       expect(response.status).toBe(201);
-      expect(mockCreateWebhook).toHaveBeenCalledWith('https://example.com');
-      expect(response.body).toEqual({ id: '123', url: 'https://example.com' });
+      expect(registerWebhookMock).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://example.com', events: [], secret: 'secret' }));
+      expect(response.body).toEqual({ id: '123', url: 'https://example.com', events: [], secret: '', status: 'active' });
     });
 
-    it('should handle invalid request (missing URL)', async () => {
+    it('should handle invalid request (validation error)', async () => {
+      (validationResult as any).mockImplementation(() => ({
+        isEmpty: () => false,
+        array: () => [{ msg: 'URL is required' }],
+      }));
+
       const response = await request(app).post('/api/webhooks').send({});
 
       expect(response.status).toBe(400);
-      expect(response.body).toEqual({ message: 'URL is required' }); // Assuming you have validation
+      expect(response.body).toEqual({ errors: [{ msg: 'URL is required' }] });
     });
 
     it('should handle service errors', async () => {
-      vi.spyOn(webhookService, 'createWebhook').mockRejectedValue(new Error('Database error'));
-      const response = await request(app).post('/api/webhooks').send({ url: 'https://example.com' });
+      const registerWebhookMock = vi.spyOn(mockWebhookService, 'registerWebhook').mockRejectedValue(new Error('Database error'));
+      const response = await request(app).post('/api/webhooks').send({ url: 'https://example.com', events: [], secret: 'secret' });
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ message: 'Failed to register webhook' });
+      expect(response.body).toEqual({ message: 'Failed to register webhook: Database error' });
     });
   });
 
   describe('DELETE /api/webhooks/:id', () => {
     it('should delete a webhook successfully', async () => {
-      const mockDeleteWebhook = vi.spyOn(webhookService, 'deleteWebhook').mockResolvedValue(true);
+      const deleteWebhookMock = vi.spyOn(mockWebhookService, 'deleteWebhook').mockResolvedValue({ message: 'Webhook deleted', webhookId: '123', success: true });
       const response = await request(app).delete('/api/webhooks/123');
 
-      expect(response.status).toBe(204);
-      expect(mockDeleteWebhook).toHaveBeenCalledWith('123');
+      expect(response.status).toBe(200);
+      expect(deleteWebhookMock).toHaveBeenCalledWith('123');
+      expect(response.body).toEqual({ message: 'Webhook deleted', webhookId: '123', success: true });
+    });
+
+    it('should handle invalid webhookId format', async () => {
+      const response = await request(app).delete('/api/webhooks/invalid-id');
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ message: 'Invalid webhookId format' });
     });
 
     it('should handle service errors when deleting', async () => {
-      vi.spyOn(webhookService, 'deleteWebhook').mockRejectedValue(new Error('Database error'));
+      const deleteWebhookMock = vi.spyOn(mockWebhookService, 'deleteWebhook').mockRejectedValue(new Error('Database error'));
       const response = await request(app).delete('/api/webhooks/123');
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ message: 'Failed to delete webhook' });
+      expect(response.body).toEqual({ message: 'Failed to delete webhook: Database error' });
     });
   });
 
   describe('GET /api/webhooks', () => {
     it('should list webhooks successfully', async () => {
-      const mockGetAllWebhooks = vi.spyOn(webhookService, 'getAllWebhooks').mockResolvedValue([{ id: '123', url: 'https://example.com' }]);
+      const listWebhooksMock = vi.spyOn(mockWebhookService, 'listWebhooks').mockResolvedValue({ webhooks: [{ id: '123', url: 'https://example.com', events: [], secret: '', active: true }], total: 1 });
       const response = await request(app).get('/api/webhooks');
 
       expect(response.status).toBe(200);
-      expect(mockGetAllWebhooks).toHaveBeenCalled();
-      expect(response.body).toEqual([{ id: '123', url: 'https://example.com' }]);
+      expect(listWebhooksMock).toHaveBeenCalled();
+      expect(response.body).toEqual({ webhooks: [{ id: '123', url: 'https://example.com', events: [], secret: '', active: true }], total: 1 });
     });
 
     it('should handle service errors when listing', async () => {
-      vi.spyOn(webhookService, 'getAllWebhooks').mockRejectedValue(new Error('Database error'));
+      const listWebhooksMock = vi.spyOn(mockWebhookService, 'listWebhooks').mockRejectedValue(new Error('Database error'));
       const response = await request(app).get('/api/webhooks');
 
       expect(response.status).toBe(500);
-      expect(response.body).toEqual({ message: 'Failed to retrieve webhooks' });
+      expect(response.body).toEqual({ message: 'Failed to list webhooks: Database error' });
+    });
+  });
+
+  describe('GET /api/webhooks/:id', () => {
+    it('should get a webhook by id successfully', async () => {
+      const getWebhookByIdMock = vi.spyOn(mockWebhookService, 'getWebhookById').mockResolvedValue({ id: '123', url: 'https://example.com', events: [], secret: '', active: true });
+      const response = await request(app).get('/api/webhooks/123');
+
+      expect(response.status).toBe(200);
+      expect(getWebhookByIdMock).toHaveBeenCalledWith('123');
+      expect(response.body).toEqual({ id: '123', url: 'https://example.com', events: [], secret: '', active: true });
+    });
+
+    it('should handle invalid webhookId format', async () => {
+      const response = await request(app).get('/api/webhooks/invalid-id');
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({ message: 'Invalid webhookId format' });
+    });
+
+    it('should handle service errors when getting by id', async () => {
+      const getWebhookByIdMock = vi.spyOn(mockWebhookService, 'getWebhookById').mockRejectedValue(new Error('Database error'));
+      const response = await request(app).get('/api/webhooks/123');
+
+      expect(response.status).toBe(500);
+      expect(response.body).toEqual({ message: 'Failed to get webhook by id: Database error' });
     });
   });
 });

--- a/src/api/services/webhook.service.test.ts
+++ b/src/api/services/webhook.service.test.ts
@@ -1,66 +1,323 @@
 // src/api/services/webhook.service.test.ts
 import { test, describe, expect, beforeEach, vi } from 'vitest';
-import * as webhookService from './webhook.service';
-import { getDB } from '../db/database';
+import { WebhookService } from './webhook.service';
+import { getDB } from '../../src/db/database';
+import { mock } from 'vitest-mock-extended';
+import { WebhookRegisterRequest, Webhook, WebhookPayload } from '../types/webhook.d';
 
-vi.mock('../db/database');
+vi.mock('../../src/db/database');
+
+const mockDB = mock<any>();
 
 describe('Webhook Service', () => {
+  let service: WebhookService;
   beforeEach(() => {
     vi.clearAllMocks();
+    (getDB as jest.Mock).mockReturnValue(mockDB);
+    service = new WebhookService(mockDB);
   });
 
-  describe('createWebhook', () => {
-    it('should create a webhook successfully', async () => {
-      const mockRun = vi.fn().mockReturnValue({ lastID: 1 });
-      (getDB as jest.Mock).mockReturnValue({ prepare: () => ({ run: mockRun }) } as any);
+  describe('registerWebhook', () => {
+    it('should register a webhook successfully', async () => {
+      const webhook: WebhookRegisterRequest = {
+        url: 'https://example.com',
+        events: ['event1'],
+        secret: 'secret',
+      };
+      const expectedWebhook: Webhook = {
+        id: expect.any(String),
+        url: webhook.url,
+        events: webhook.events,
+        secret: webhook.secret,
+        active: true,
+      };
 
-      const result = await webhookService.createWebhook('https://example.com');
+      mockDB.run.mockResolvedValue({ changes: 1 });
 
-      expect(result).toEqual({ id: '1', url: 'https://example.com' });
-      expect(mockRun).toHaveBeenCalled();
+      const result = await service.registerWebhook(webhook);
+
+      expect(mockDB.run).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO webhooks'),
+        expect.any(String),
+        webhook.url,
+        JSON.stringify(webhook.events),
+        webhook.secret,
+        1
+      );
+      expect(result).toMatchObject(expectedWebhook);
     });
 
     it('should handle database errors', async () => {
-      (getDB as jest.Mock).mockReturnValue({ prepare: () => ({ run: vi.fn().mockImplementation(() => { throw new Error('DB Error') }) }) } as any);
+      const webhook: WebhookRegisterRequest = {
+        url: 'https://example.com',
+        events: ['event1'],
+        secret: 'secret',
+      };
+      mockDB.run.mockRejectedValue(new Error('DB Error'));
 
-      await expect(webhookService.createWebhook('https://example.com')).rejects.toThrow('DB Error');
+      await expect(service.registerWebhook(webhook)).rejects.toThrow('Failed to register webhook: DB Error');
+      expect(mockDB.run).toHaveBeenCalled();
     });
   });
 
   describe('deleteWebhook', () => {
     it('should delete a webhook successfully', async () => {
-      const mockRun = vi.fn().mockReturnValue({ changes: 1 });
-      (getDB as jest.Mock).mockReturnValue({ prepare: () => ({ run: mockRun }) } as any);
+      mockDB.run.mockResolvedValue({ changes: 1 });
 
-      const result = await webhookService.deleteWebhook('123');
+      const result = await service.deleteWebhook('123');
 
-      expect(result).toBe(true);
-      expect(mockRun).toHaveBeenCalled();
+      expect(result).toEqual({ message: 'Webhook deleted', webhookId: '123', success: true });
+      expect(mockDB.run).toHaveBeenCalledWith('DELETE FROM webhooks WHERE id = ?', ['123']);
+    });
+
+    it('should handle webhook not found', async () => {
+      mockDB.run.mockResolvedValue({ changes: 0 });
+
+      const result = await service.deleteWebhook('123');
+
+      expect(result).toEqual({ message: 'Webhook not found', webhookId: '123', success: false });
+      expect(mockDB.run).toHaveBeenCalledWith('DELETE FROM webhooks WHERE id = ?', ['123']);
     });
 
     it('should handle database errors during deletion', async () => {
-      (getDB as jest.Mock).mockReturnValue({ prepare: () => ({ run: vi.fn().mockImplementation(() => { throw new Error('DB Error') }) }) } as any);
+      mockDB.run.mockRejectedValue(new Error('DB Error'));
 
-      await expect(webhookService.deleteWebhook('123')).rejects.toThrow('DB Error');
+      await expect(service.deleteWebhook('123')).rejects.toThrow('Failed to delete webhook: DB Error');
+      expect(mockDB.run).toHaveBeenCalledWith('DELETE FROM webhooks WHERE id = ?', ['123']);
     });
   });
 
-  describe('getAllWebhooks', () => {
+  describe('listWebhooks', () => {
     it('should get all webhooks successfully', async () => {
-      const mockAll = vi.fn().mockReturnValue([{ id: 1, url: 'https://example.com' }]);
-      (getDB as jest.Mock).mockReturnValue({ prepare: () => ({ all: mockAll }) } as any);
+      const mockWebhooks: Webhook[] = [
+        {
+          id: '1',
+          url: 'https://example.com',
+          events: ['event1'],
+          secret: 'secret',
+          active: true,
+        },
+      ];
+      mockDB.all.mockResolvedValue([
+        {
+          id: '1',
+          url: 'https://example.com',
+          events: JSON.stringify(['event1']),
+          secret: 'secret',
+          active: 1,
+        },
+      ]);
 
-      const result = await webhookService.getAllWebhooks();
+      const result = await service.listWebhooks();
 
-      expect(result).toEqual([{ id: '1', url: 'https://example.com' }]);
-      expect(mockAll).toHaveBeenCalled();
+      expect(result).toEqual({ webhooks: mockWebhooks, total: 1 });
+      expect(mockDB.all).toHaveBeenCalledWith('SELECT * FROM webhooks');
     });
 
     it('should handle database errors during get all', async () => {
-      (getDB as jest.Mock).mockReturnValue({ prepare: () => ({ all: vi.fn().mockImplementation(() => { throw new Error('DB Error') }) }) } as any);
+      mockDB.all.mockRejectedValue(new Error('DB Error'));
 
-      await expect(webhookService.getAllWebhooks()).rejects.toThrow('DB Error');
+      await expect(service.listWebhooks()).rejects.toThrow('Failed to list webhooks: DB Error');
+      expect(mockDB.all).toHaveBeenCalledWith('SELECT * FROM webhooks');
+    });
+  });
+
+  describe('getWebhookById', () => {
+    it('should get webhook by id successfully', async () => {
+      const mockWebhook: Webhook = {
+        id: '1',
+        url: 'https://example.com',
+        events: ['event1'],
+        secret: 'secret',
+        active: true,
+      };
+      mockDB.get.mockResolvedValue({
+        id: '1',
+        url: 'https://example.com',
+        events: JSON.stringify(['event1']),
+        secret: 'secret',
+        active: 1,
+      });
+
+      const result = await service.getWebhookById('1');
+
+      expect(result).toEqual(mockWebhook);
+      expect(mockDB.get).toHaveBeenCalledWith('SELECT * FROM webhooks WHERE id = ?', ['1']);
+    });
+
+    it('should return undefined if webhook is not found', async () => {
+      mockDB.get.mockResolvedValue(undefined);
+
+      const result = await service.getWebhookById('1');
+
+      expect(result).toBeUndefined();
+      expect(mockDB.get).toHaveBeenCalledWith('SELECT * FROM webhooks WHERE id = ?', ['1']);
+    });
+
+    it('should handle database errors', async () => {
+      mockDB.get.mockRejectedValue(new Error('DB Error'));
+
+      await expect(service.getWebhookById('1')).rejects.toThrow('Failed to get webhook by id: DB Error');
+      expect(mockDB.get).toHaveBeenCalledWith('SELECT * FROM webhooks WHERE id = ?', ['1']);
+    });
+  });
+
+  describe('processWebhookEvent', () => {
+    it('should process webhook event successfully', async () => {
+      const payload: WebhookPayload = {
+        event: 'event1',
+        data: { some: 'data' },
+      };
+      const mockWebhook: Webhook = {
+        id: '1',
+        url: 'https://example.com',
+        events: ['event1'],
+        secret: 'secret',
+        active: true,
+      };
+      mockDB.all.mockResolvedValue([
+        {
+          id: '1',
+          url: 'https://example.com',
+          events: JSON.stringify(['event1']),
+          secret: 'secret',
+          active: 1,
+        },
+      ]);
+      // Mock the invokeWebhook function
+      const invokeWebhookSpy = vi.spyOn(service, 'invokeWebhook' as any);
+
+      await service.processWebhookEvent(payload);
+
+      expect(mockDB.all).toHaveBeenCalledWith('SELECT * FROM webhooks WHERE events LIKE ? AND active = 1', ['%event1%']);
+      expect(invokeWebhookSpy).toHaveBeenCalledWith(mockWebhook, payload);
+    });
+
+    it('should not invoke webhook if event does not match', async () => {
+      const payload: WebhookPayload = {
+        event: 'event2',
+        data: { some: 'data' },
+      };
+
+      mockDB.all.mockResolvedValue([
+        {
+          id: '1',
+          url: 'https://example.com',
+          events: JSON.stringify(['event1']),
+          secret: 'secret',
+          active: 1,
+        },
+      ]);
+      // Mock the invokeWebhook function
+      const invokeWebhookSpy = vi.spyOn(service, 'invokeWebhook' as any);
+
+      await service.processWebhookEvent(payload);
+
+      expect(mockDB.all).toHaveBeenCalledWith('SELECT * FROM webhooks WHERE events LIKE ? AND active = 1', ['%event2%']);
+      expect(invokeWebhookSpy).not.toHaveBeenCalled();
+    });
+
+    it('should handle database errors', async () => {
+      const payload: WebhookPayload = {
+        event: 'event1',
+        data: { some: 'data' },
+      };
+      mockDB.all.mockRejectedValue(new Error('DB Error'));
+
+      await expect(service.processWebhookEvent(payload)).rejects.toThrow('Failed to process webhook event: DB Error');
+      expect(mockDB.all).toHaveBeenCalledWith('SELECT * FROM webhooks WHERE events LIKE ? AND active = 1', ['%event1%']);
+    });
+  });
+
+  describe('invokeWebhook', () => {
+    it('should invoke webhook successfully with secret', async () => {
+      const webhook: Webhook = {
+        id: '1',
+        url: 'https://example.com',
+        events: ['event1'],
+        secret: 'secret',
+        active: true,
+      };
+      const payload: WebhookPayload = {
+        event: 'event1',
+        data: { some: 'data' },
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      global.fetch = mockFetch;
+      const generateSignatureSpy = vi.spyOn(service, 'generateSignature' as any).mockReturnValue('signature');
+
+      await (service as any).invokeWebhook(webhook, payload);
+
+      expect(mockFetch).toHaveBeenCalledWith('https://example.com', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Signature': 'signature',
+        },
+        body: JSON.stringify(payload),
+      });
+      expect(generateSignatureSpy).toHaveBeenCalledWith(JSON.stringify(payload), 'secret');
+    });
+
+    it('should invoke webhook successfully without secret', async () => {
+      const webhook: Webhook = {
+        id: '1',
+        url: 'https://example.com',
+        events: ['event1'],
+        secret: undefined,
+        active: true,
+      };
+      const payload: WebhookPayload = {
+        event: 'event1',
+        data: { some: 'data' },
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      global.fetch = mockFetch;
+
+      await (service as any).invokeWebhook(webhook, payload);
+
+      expect(mockFetch).toHaveBeenCalledWith('https://example.com', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+    });
+
+    it('should handle fetch errors', async () => {
+      const webhook: Webhook = {
+        id: '1',
+        url: 'https://example.com',
+        events: ['event1'],
+        secret: 'secret',
+        active: true,
+      };
+      const payload: WebhookPayload = {
+        event: 'event1',
+        data: { some: 'data' },
+      };
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+      global.fetch = mockFetch;
+
+      await (service as any).invokeWebhook(webhook, payload);
+
+      expect(mockFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe('generateSignature', () => {
+    it('should generate a signature', () => {
+      const data = '{"event":"event1","data":{"some":"data"}}';
+      const secret = 'secret';
+      const expectedSignature = 'b03ef1a93e04709203c8288d502b917c12435788c5a7bb6f21533582c82b98e2';
+
+      const signature = (service as any).generateSignature(data, secret);
+
+      expect(signature).toBe(expectedSignature);
     });
   });
 });


### PR DESCRIPTION
Adds unit tests for webhook API controllers and services using Vitest.  Includes tests for registerWebhook, deleteWebhook, listWebhooks, and getWebhookById in the controller, and registerWebhook, deleteWebhook, listWebhooks, getWebhookById, processWebhookEvent, invokeWebhook, and generateSignature in the service.  Mocks dependencies and tests various scenarios, including successful requests, invalid requests, and error conditions.