### PR TITLE
ATM-1021: Implement webhook triggering logic in API endpoints

### DIFF
--- a/src/api/controllers/issue.controller.ts
+++ b/src/api/controllers/issue.controller.ts
@@ -1,9 +1,14 @@
 // src/api/controllers/issue.controller.ts
 import { Request, Response } from 'express';
 import { findIssues as findIssuesService } from '../services/issue.service';
-import { createIssue as createIssueService } from '../services/issue.service';
+import { createIssue as createIssueService, updateIssue as updateIssueService } from '../services/issue.service';
+import { WebhookService } from '../services/webhook.service';
+import Database from '../../src/db/database';
 
-export const findIssues = async (req: Request, res: Response) => {  
+const db = new Database('./data/task_manager.db');
+const webhookService = new WebhookService(db);
+
+export const findIssues = async (req: Request, res: Response) => {
   try {
     const { keywords, status, assignee } = req.query;
     const searchResults = await findIssuesService(keywords as string | undefined, status as string | undefined, assignee as string | undefined);
@@ -18,9 +23,29 @@ export const createIssue = async (req: Request, res: Response) => {
   try {
     const newIssueData = req.body;
     const createdIssue = await createIssueService(newIssueData);
+
+    // Trigger webhook for issue created event
+    await webhookService.processWebhookEvent({ event: 'issue.created', issue: createdIssue });
+
     res.status(201).json(createdIssue);
   } catch (error: any) {
     console.error('Error creating issue:', error);
-    res.status(400).json({ message: error.message || 'Invalid request' }); // Consider different error codes for different errors
+    res.status(400).json({ message: error.message || 'Invalid request' });
   }
+};
+
+export const updateIssue = async (req: Request, res: Response) => {
+    try {
+        const { issueKey } = req.params;
+        const updateData = req.body;
+        const updatedIssue = await updateIssueService(issueKey, updateData);
+
+        // Trigger webhook for issue updated event
+        await webhookService.processWebhookEvent({ event: 'issue.updated', issue: updatedIssue });
+
+        res.status(200).json(updatedIssue);
+    } catch (error: any) {
+        console.error('Error updating issue:', error);
+        res.status(400).json({ message: error.message || 'Invalid request' });
+    }
 };

--- a/src/api/services/issue.service.ts
+++ b/src/api/services/issue.service.ts
@@ -23,3 +23,17 @@ export const createIssue = async (issueData: any): Promise<Issue> => {
   };
   return newIssue;
 };
+
+export const updateIssue = async (issueKey: string, updateData: any): Promise<Issue> => {
+  // Placeholder implementation
+  // In a real application, this would interact with a database
+    const updatedIssue: Issue = {
+        id: issueKey,
+        summary: updateData.summary || 'Updated Summary',
+        description: updateData.description || 'Updated Description',
+        type: updateData.type || 'Task',
+        project: updateData.project || 'ATM',
+        status: updateData.status || 'In Progress',
+    };
+    return updatedIssue;
+};


### PR DESCRIPTION
Implemented webhook triggering logic in API endpoints for issue creation and updates.  This includes calling the `webhookService.processWebhookEvent` with the appropriate event type and issue data within the `createIssue` and `updateIssue` controllers.