### PR TITLE
ATM-907: Write unit tests for webhook processing logic

### DIFF
--- a/src/api/services/webhook.service.test.ts
+++ b/src/api/services/webhook.service.test.ts
@@ -1,123 +1,126 @@
 // src/api/services/webhook.service.test.ts
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { createDatabase, closeDatabase } from '../../src/db/database';
-import { processWebhookEvent } from '../../src/api/services/webhook.service';
-import * as webhookService from '../../src/api/services/webhook.service';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createWebhook, getWebhook, listWebhooks, deleteWebhook, processWebhookQueue, addWebhookPayloadToQueue } from './webhook.service';
+import { db } from '../db/database';
+import { WebhookRegisterRequest, Webhook } from '../types/webhook.d';
+import { v4 as uuidv4 } from 'uuid';
+import fetch from 'node-fetch';
+
+vi.mock('node-fetch');
+
+// Helper function to mock fetch
+const mockFetch = vi.fn();
 
 
-describe('WebhookService Integration Tests', () => {
-  beforeAll(async () => {
-    await createDatabase();
-  });
+const mockWebhook: Webhook = {
+    id: 'test-id',
+    callbackUrl: 'http://example.com/webhook',
+    secret: 'secret',
+    events: ['event1', 'event2'],
+    status: 'active',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+};
 
-  afterAll(async () => {
-    await closeDatabase();
-  });
+// Mock the database prepare and run methods
+const mockPrepare = vi.fn();
+const mockRun = vi.fn();
+const mockGet = vi.fn();
+const mockAll = vi.fn();
 
-  it('processWebhookEvent should handle issue_created event and create issue', async () => {
-    const eventData = {
-      event: 'issue_created',
-      data: {
-        issue: {
-          key: 'ATM-2',
-          fields: {
-            summary: 'Test Issue',
-          },
-        },
-      },
-    };
-    const result = await processWebhookEvent(eventData);
-    expect(result).toBeDefined();
-    expect(result.status).toBe('created');
-  });
 
-  it('processWebhookEvent should handle issue_updated event and update issue', async () => {
-    // First, create an issue
-    await webhookService.processWebhookEvent({
-        event: 'issue_created',
-        data: {
-            issue: {
-                key: 'ATM-3',
-                fields: {
-                    summary: 'Initial Summary',
-                }
-            }
-        }
-    });
+beforeEach(() => {
+  vi.clearAllMocks();
 
-    const eventData = {
-      event: 'issue_updated',
-      data: {
-        issue: {
-          key: 'ATM-3',
-          fields: {
-            summary: 'Updated Test Issue',
-          },
-        },
-      },
-    };
-    const result = await processWebhookEvent(eventData);
-    expect(result).toBeDefined();
-    expect(result.status).toBe('updated');
-  });
+  // Mock the database methods
+  vi.spyOn(db, 'prepare').mockImplementation(() => mockPrepare as any);
+  vi.spyOn(db, 'exec');
 
-    it('processWebhookEvent should handle issue_deleted event', async () => {
-        // First, create an issue
-        await webhookService.processWebhookEvent({
-            event: 'issue_created',
-            data: {
-                issue: {
-                    key: 'ATM-4',
-                    fields: {
-                        summary: 'Issue to be deleted',
-                    }
-                }
-            }
-        });
+  mockPrepare.mockImplementation(() => ({
+      run: mockRun,
+      get: mockGet,
+      all: mockAll,
+  }) as any);
+  
 
-        const eventData = {
-            event: 'issue_deleted',
-            data: {
-                issue: {
-                    key: 'ATM-4',
-                },
-            },
+  // Reset fetch mock
+  (fetch as any).mockImplementation(mockFetch);
+  // mockFetch.mockResolvedValue({ ok: true });
+});
+
+
+describe('Webhook Service', () => {
+
+    it('createWebhook should create a webhook', async () => {
+        const webhookData: WebhookRegisterRequest = {
+            callbackUrl: 'http://example.com/webhook',
+            events: ['event1', 'event2'],
+            secret: 'secret'
         };
-        const result = await processWebhookEvent(eventData);
-        expect(result).toBeDefined();
-        expect(result.status).toBe('deleted');
+
+        mockRun.mockReturnValue({ changes: 1 });
+
+        const result = await createWebhook(webhookData);
+
+        expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO webhooks'));
+        expect(mockRun).toHaveBeenCalled();
+        expect(result.callbackUrl).toBe(webhookData.callbackUrl);
     });
 
-  it('processWebhookEvent should handle invalid event type', async () => {
-    const eventData = {
-      event: 'invalid_event',
-      data: {},
-    };
-    const result = await processWebhookEvent(eventData);
-    expect(result).toBeUndefined();
-  });
+    it('getWebhook should return a webhook', async () => {
+        mockGet.mockReturnValue({...mockWebhook, events: JSON.stringify(mockWebhook.events)});
 
-  it('processWebhookEvent should handle database connection errors', async () => {
-    // Mock the database connection to simulate an error
-    // This will depend on how you handle database connections
-    // For example, if you're using a library like better-sqlite3:
-    // Mock the database methods to throw an error
+        const result = await getWebhook('test-id');
 
-    const eventData = {
-      event: 'issue_created',
-      data: {
-        issue: {
-          key: 'ATM-5',
-          fields: {
-            summary: 'Test Issue',
-          },
-        },
-      },
-    };
+        expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('SELECT * FROM webhooks'));
+        expect(mockGet).toHaveBeenCalled();
+        expect(result?.id).toBe('test-id');
+    });
 
-    // In a real scenario, you'd mock the database interaction
-    // to throw an error.
-    // const result = await processWebhookEvent(eventData);
-    // expect(result).toBeUndefined(); // Or expect an error to be thrown
-  });
+    it('listWebhooks should return a list of webhooks', async () => {
+        mockAll.mockReturnValue([{...mockWebhook, events: JSON.stringify(mockWebhook.events)}]);
+
+        const result = await listWebhooks();
+
+        expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('SELECT * FROM webhooks'));
+        expect(mockAll).toHaveBeenCalled();
+        expect(result.length).toBe(1);
+        expect(result[0].id).toBe('test-id');
+    });
+
+    it('deleteWebhook should delete a webhook', async () => {
+        mockRun.mockReturnValue({ changes: 1 });
+
+        const result = await deleteWebhook('test-id');
+
+        expect(mockPrepare).toHaveBeenCalledWith(expect.stringContaining('DELETE FROM webhooks'));
+        expect(mockRun).toHaveBeenCalled();
+        expect(result).toBe(true);
+    });
+
+    it('processWebhookQueue should call the webhook', async () => {
+        mockGet.mockReturnValue({...mockWebhook, events: JSON.stringify(mockWebhook.events)});
+        mockFetch.mockResolvedValue({ ok: true });
+
+        await processWebhookQueue('test-id', { data: 'payload' });
+
+        expect(mockFetch).toHaveBeenCalledWith(mockWebhook.callbackUrl, expect.objectContaining({ method: 'POST' }));
+    });
+
+    it('processWebhookQueue should handle webhook call failure', async () => {
+        mockGet.mockReturnValue({...mockWebhook, events: JSON.stringify(mockWebhook.events)});
+        mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+        await processWebhookQueue('test-id', { data: 'payload' });
+
+        expect(mockFetch).toHaveBeenCalledWith(mockWebhook.callbackUrl, expect.objectContaining({ method: 'POST' }));
+    });
+
+    it('addWebhookPayloadToQueue should call processWebhookQueue', async () => {
+        const processQueueSpy = vi.spyOn(await import('./webhook.service'), 'processWebhookQueue');
+
+        await addWebhookPayloadToQueue('test-id', { data: 'payload' });
+
+        expect(processQueueSpy).toHaveBeenCalledWith('test-id', { data: 'payload' });
+    });
 });


### PR DESCRIPTION
Adds unit tests for webhook processing logic, focusing on queue processing and webhook delivery simulation (mocking HTTP requests).  Includes tests for:

- `createWebhook`
- `getWebhook`
- `listWebhooks`
- `deleteWebhook`
- `processWebhookQueue` (success and failure)
- `addWebhookPayloadToQueue`