### PR TITLE
ATM-971: Define API endpoint for Transition issue - POST /issues/:issueKey/transitions

### DIFF
--- a/src/api/controllers/issue.controller.ts
+++ b/src/api/controllers/issue.controller.ts
@@ -15,7 +15,7 @@ export async function createIssue(req: Request, res: Response) {
         const end = Date.now();
         console.log(`createIssue took ${end - start}ms`);
         res.status(500).json({ message: error.message });
-    } 
+    }
 }
 
 export async function getIssue(req: Request, res: Response) {
@@ -86,3 +86,18 @@ export async function deleteIssue(req: Request, res: Response) {
         res.status(500).json({ message: error.message });
     }
 }
+
+export async function transitionIssue(req: Request, res: Response) {
+    // Implement the transition logic here
+    const issueKey = req.params.issueKey;
+    const transitionData = req.body;
+
+    try {
+      // Assuming you have a service function to handle the transition
+      await issueService.transitionIssue(issueKey, transitionData);
+      res.status(200).json({ message: 'Issue transitioned successfully' });
+    } catch (error: any) {
+      console.error("Transition failed:", error);
+      res.status(500).json({ message: error.message || 'Failed to transition issue' });
+    }
+  }

--- a/src/api/routes/issue.routes.ts
+++ b/src/api/routes/issue.routes.ts
@@ -9,5 +9,6 @@ router.post('/issues', issueController.createIssue);
 router.get('/issues/:id', issueController.getIssue);
 router.put('/issues/:issueKey', issueController.updateIssue);
 router.delete('/issues/:id', issueController.deleteIssue);
+router.post('/issues/:issueKey/transitions', issueController.transitionIssue); // Add this line
 
 export default router;


### PR DESCRIPTION
Adds the API endpoint for transitioning issues.  

- Defines the POST /issues/:issueKey/transitions endpoint.
- Includes basic error handling and response formatting.
- Relies on `issueService.transitionIssue` for the actual transition logic (to be implemented in a subsequent task).
