### PR TITLE
ATM-980: Write unit tests for each API endpoint

### DIFF
--- a/src/api/controllers/issue.controller.test.ts
+++ b/src/api/controllers/issue.controller.test.ts
@@ -1,252 +1,216 @@
 // src/api/controllers/issue.controller.test.ts
 
-import request from 'supertest';
-import app from '../../src/index'; // Assuming your app is exported
-import * as issueService from '../../src/api/services/issue.service'; // Corrected import
-import { Issue } from '../../src/types/issue.d';
-import { describe, it, expect, beforeEach, vi, beforeAll, afterAll } from 'vitest'; // Import Vitest functions
-import { createDatabase, closeDatabase } from '../../src/db/database';
-import Database from 'better-sqlite3';
+import { createIssue, getIssue, updateIssue, deleteIssue, transitionIssue } from './issue.controller';
+import * as issueService from '../services/issue.service';
+import { Request, Response } from 'express';
 
-vi.mock('../../src/api/services/issue.service'); // Use vi.mock for Vitest
+// Mock the issue service
+jest.mock('../services/issue.service');
 
 describe('Issue Controller', () => {
+  let mockRequest: any;
+  let mockResponse: any;
+
   beforeEach(() => {
-    vi.clearAllMocks(); // Clear mocks before each test
+    mockRequest = {
+      body: {},
+      params: {},
+    };
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
   });
 
-  beforeAll(async () => {
-    await createDatabase();
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  afterAll(async () => {
-    await closeDatabase();
+  describe('createIssue', () => {
+    it('should create an issue and return 201 with the issue data', async () => {
+      const mockIssue = { id: 1, summary: 'Test issue', description: 'Test description', status: 'Open' };
+      (issueService.createIssue as jest.Mock).mockResolvedValue(mockIssue);
+      mockRequest.body = { summary: 'Test issue', description: 'Test description', status: 'Open' };
+
+      await createIssue(mockRequest as Request, mockResponse as Response);
+
+      expect(issueService.createIssue).toHaveBeenCalledWith(mockRequest.body);
+      expect(mockResponse.status).toHaveBeenCalledWith(201);
+      expect(mockResponse.json).toHaveBeenCalledWith(mockIssue);
+    });
+
+    it('should return 500 if issue creation fails', async () => {
+      (issueService.createIssue as jest.Mock).mockRejectedValue(new Error('Failed to create issue'));
+      mockRequest.body = { summary: 'Test issue', description: 'Test description', status: 'Open' };
+
+      await createIssue(mockRequest as Request, mockResponse as Response);
+
+      expect(issueService.createIssue).toHaveBeenCalledWith(mockRequest.body);
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Failed to create issue' });
+    });
   });
 
-  describe('GET /issues/:id', () => {
-    it('should get an issue and return 200 if found', async () => {
-      const mockIssue: Issue = {
-        id: 1,
-        summary: 'Test issue',
-        description: 'This is a test issue',
-        status: 'open',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-      (issueService.getIssue as any).mockResolvedValue(mockIssue);
+  describe('getIssue', () => {
+    it('should get an issue and return 200 with the issue data', async () => {
+      const mockIssue = { id: 1, summary: 'Test issue', description: 'Test description', status: 'Open' };
+      (issueService.getIssue as jest.Mock).mockResolvedValue(mockIssue);
+      mockRequest.params = { id: '1' };
 
-      const response = await request(app).get('/issues/1');
+      await getIssue(mockRequest as Request, mockResponse as Response);
 
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toEqual(mockIssue);
       expect(issueService.getIssue).toHaveBeenCalledWith(1);
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith(mockIssue);
+    });
+
+    it('should return 400 if issueId is invalid', async () => {
+      mockRequest.params = { id: 'abc' };
+
+      await getIssue(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Invalid issue ID' });
     });
 
     it('should return 404 if issue is not found', async () => {
-      (issueService.getIssue as any).mockResolvedValue(undefined);
+      (issueService.getIssue as jest.Mock).mockResolvedValue(null);
+      mockRequest.params = { id: '1' };
 
-      const response = await request(app).get('/issues/999');
+      await getIssue(mockRequest as Request, mockResponse as Response);
 
-      expect(response.statusCode).toBe(404);
-      expect(issueService.getIssue).toHaveBeenCalledWith(999);
+      expect(issueService.getIssue).toHaveBeenCalledWith(1);
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Issue not found' });
     });
 
-    it('should return 400 for an invalid id', async () => {
-      const response = await request(app).get('/issues/abc');
+    it('should return 500 if getting issue fails', async () => {
+      (issueService.getIssue as jest.Mock).mockRejectedValue(new Error('Failed to get issue'));
+      mockRequest.params = { id: '1' };
 
-      expect(response.statusCode).toBe(400);
-      expect(response.body.message).toBe('Invalid issue ID');
-    });
+      await getIssue(mockRequest as Request, mockResponse as Response);
 
-    it('should return 500 if issueService.getIssue throws an error', async () => {
-      (issueService.getIssue as any).mockRejectedValue(new Error('Service error'));
-
-      const response = await request(app).get('/issues/1');
-
-      expect(response.statusCode).toBe(500);
-      expect(response.body.message).toBe('Service error');
+      expect(issueService.getIssue).toHaveBeenCalledWith(1);
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Failed to get issue' });
     });
   });
 
-  describe('POST /issues', () => {
-    it('should create a new issue and return 201', async () => {
-      const newIssueData = {
-        summary: 'New issue',
-        description: 'This is a new issue',
-        status: 'open',
-      };
-      const mockIssue: Issue = {
-        id: 2,
-        ...newIssueData,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-      (issueService.createIssue as any).mockResolvedValue(mockIssue);
-
-      const response = await request(app).post('/issues').send(newIssueData).set('Content-Type', 'application/json');
-
-      expect(response.statusCode).toBe(201);
-      expect(response.body).toEqual(mockIssue);
-      expect(issueService.createIssue).toHaveBeenCalledWith(newIssueData);
-    });
-
-    it('should return 400 if the request body is invalid', async () => {
-      const response = await request(app).post('/issues').send({ invalid: 'data' }).set('Content-Type', 'application/json');
-
-      expect(response.statusCode).toBe(400);
-    });
-
-    it('should return 500 if issueService.createIssue throws an error', async () => {
-      (issueService.createIssue as any).mockRejectedValue(new Error('Service error'));
-      const response = await request(app).post('/issues').send({ summary: 'test', description: 'test', status: 'open' }).set('Content-Type', 'application/json');
-      expect(response.statusCode).toBe(500);
-      expect(response.body.message).toBe('Service error');
-    });
-
-    it('should rollback transaction on create issue database error', async () => {
-        const newIssueData = {
-            summary: 'New issue',
-            description: 'This is a new issue',
-            status: 'open',
-        };
-
-        const mockExec = vi.fn();
-        // Mock the createIssue function to throw an error
-        (issueService.createIssue as any).mockImplementation(() => {
-            throw new Error('Simulated database error');
-        });
-
-        // Mock db.exec to spy on the rollback
-        const dbMock = {
-          exec: mockExec
-        };
-        vi.mock('../../src/db/database', () => ({
-          ...jest.requireActual('../../src/db/database'),
-          db: dbMock,
-        }));
-
-        const response = await request(app).post('/issues').send(newIssueData).set('Content-Type', 'application/json');
-
-        expect(response.statusCode).toBe(500);
-        expect(response.body.message).toBe('Simulated database error');
-        expect(mockExec).toHaveBeenCalledWith('ROLLBACK');
-    });
-  });
-
-  describe('PUT /issues/:id', () => {
+  describe('updateIssue', () => {
     it('should update an issue and return 200', async () => {
-      const updateData = {
-        summary: 'Updated issue',
-      };
-      (issueService.updateIssue as any).mockResolvedValue({ changes: 1 });
+      (issueService.updateIssue as jest.Mock).mockResolvedValue({ changes: 1 });
+      mockRequest.params = { issueKey: '1' };
+      mockRequest.body = { summary: 'Updated summary' };
 
-      const response = await request(app).put('/issues/1').send(updateData).set('Content-Type', 'application/json');
+      await updateIssue(mockRequest as Request, mockResponse as Response);
 
-      expect(response.statusCode).toBe(200);
-      expect(issueService.updateIssue).toHaveBeenCalledWith(1, updateData);
-      expect(response.body.message).toBe('Issue updated');
+      expect(issueService.updateIssue).toHaveBeenCalledWith(1, mockRequest.body);
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Issue updated' });
     });
 
-    it('should return 400 for an invalid id', async () => {
-        const response = await request(app).put('/issues/abc').send({ summary: 'Updated issue' }).set('Content-Type', 'application/json');
+    it('should return 400 if issueKey is invalid', async () => {
+      mockRequest.params = { issueKey: 'abc' };
+      mockRequest.body = { summary: 'Updated summary' };
 
-        expect(response.statusCode).toBe(400);
-        expect(response.body.message).toBe('Invalid issue ID');
+      await updateIssue(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Invalid issue ID' });
     });
 
-    it('should return 404 if issue is not found', async () => {
-      (issueService.updateIssue as any).mockResolvedValue({ changes: 0 });
+    it('should return 404 if issue is not found or no changes', async () => {
+      (issueService.updateIssue as jest.Mock).mockResolvedValue({ changes: 0 });
+      mockRequest.params = { issueKey: '1' };
+      mockRequest.body = { summary: 'Updated summary' };
 
-      const response = await request(app).put('/issues/999').send({ summary: 'Updated issue' }).set('Content-Type', 'application/json');
+      await updateIssue(mockRequest as Request, mockResponse as Response);
 
-      expect(response.statusCode).toBe(404);
-      expect(issueService.updateIssue).toHaveBeenCalledWith(999, expect.anything());
-      expect(response.body.message).toBe('Issue not found or no changes');
+      expect(issueService.updateIssue).toHaveBeenCalledWith(1, mockRequest.body);
+      expect(mockResponse.status).toHaveBeenCalledWith(404);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Issue not found or no changes' });
     });
 
-    it('should return 500 if issueService.updateIssue throws an error', async () => {
-      (issueService.updateIssue as any).mockRejectedValue(new Error('Service error'));
+    it('should return 500 if updating issue fails', async () => {
+      (issueService.updateIssue as jest.Mock).mockRejectedValue(new Error('Failed to update issue'));
+      mockRequest.params = { issueKey: '1' };
+      mockRequest.body = { summary: 'Updated summary' };
 
-      const response = await request(app).put('/issues/1').send({ summary: 'Updated issue' }).set('Content-Type', 'application/json');
+      await updateIssue(mockRequest as Request, mockResponse as Response);
 
-      expect(response.statusCode).toBe(500);
-      expect(response.body.message).toBe('Service error');
-    });
-
-    it('should rollback transaction on update issue database error', async () => {
-        const updateData = {
-            summary: 'Updated issue',
-        };
-
-        const mockExec = vi.fn();
-        // Mock the updateIssue function to throw an error
-        (issueService.updateIssue as any).mockImplementation(() => {
-            throw new Error('Simulated database error');
-        });
-
-        // Mock db.exec to spy on the rollback
-        const dbMock = {
-          exec: mockExec
-        };
-        vi.mock('../../src/db/database', () => ({
-          ...jest.requireActual('../../src/db/database'),
-          db: dbMock,
-        }));
-
-        const response = await request(app).put('/issues/1').send(updateData).set('Content-Type', 'application/json');
-
-        expect(response.statusCode).toBe(500);
-        expect(response.body.message).toBe('Simulated database error');
-        expect(mockExec).toHaveBeenCalledWith('ROLLBACK');
+      expect(issueService.updateIssue).toHaveBeenCalledWith(1, mockRequest.body);
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Failed to update issue' });
     });
   });
 
-  describe('DELETE /issues/:id', () => {
+  describe('deleteIssue', () => {
     it('should delete an issue and return 204', async () => {
-      (issueService.deleteIssue as any).mockResolvedValue(undefined);
+      (issueService.deleteIssue as jest.Mock).mockResolvedValue(undefined);
+      mockRequest.params = { id: '1' };
 
-      const response = await request(app).delete('/issues/1');
+      await deleteIssue(mockRequest as Request, mockResponse as Response);
 
-      expect(response.statusCode).toBe(204);
       expect(issueService.deleteIssue).toHaveBeenCalledWith(1);
+      expect(mockResponse.status).toHaveBeenCalledWith(204);
+      expect(mockResponse.send).toHaveBeenCalled();
     });
 
-    it('should return 400 for an invalid id', async () => {
-      const response = await request(app).delete('/issues/abc');
+    it('should return 400 if issueId is invalid', async () => {
+      mockRequest.params = { id: 'abc' };
 
-      expect(response.statusCode).toBe(400);
-      expect(response.body.message).toBe('Invalid issue ID');
+      await deleteIssue(mockRequest as Request, mockResponse as Response);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Invalid issue ID' });
     });
 
-    it('should return 500 if issueService.deleteIssue throws an error', async () => {
-      (issueService.deleteIssue as any).mockRejectedValue(new Error('Service error'));
+    it('should return 500 if deleting issue fails', async () => {
+      (issueService.deleteIssue as jest.Mock).mockRejectedValue(new Error('Failed to delete issue'));
+      mockRequest.params = { id: '1' };
 
-      const response = await request(app).delete('/issues/1');
+      await deleteIssue(mockRequest as Request, mockResponse as Response);
 
-      expect(response.statusCode).toBe(500);
-      expect(response.body.message).toBe('Service error');
+      expect(issueService.deleteIssue).toHaveBeenCalledWith(1);
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Failed to delete issue' });
+    });
+  });
+
+  describe('transitionIssue', () => {
+    it('should transition an issue and return 200', async () => {
+      (issueService.transitionIssue as jest.Mock).mockResolvedValue({ message: 'Issue transitioned successfully' });
+      mockRequest.params = { issueKey: '1' };
+      mockRequest.body = { transitionId: '2' };
+
+      await transitionIssue(mockRequest as Request, mockResponse as Response);
+
+      expect(issueService.transitionIssue).toHaveBeenCalledWith('1', mockRequest.body);
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Issue transitioned successfully' });
     });
 
-    it('should rollback transaction on delete issue database error', async () => {
-        // Mock the deleteIssue function to throw an error
-        (issueService.deleteIssue as any).mockImplementation(() => {
-            throw new Error('Simulated database error');
-        });
-        const mockExec = vi.fn();
-        // Mock db.exec to spy on the rollback
-        const dbMock = {
-          exec: mockExec
-        };
-        vi.mock('../../src/db/database', () => ({
-          ...jest.requireActual('../../src/db/database'),
-          db: dbMock,
-        }));
+    it('should return 400 if issueKey is invalid', async () => {
+      mockRequest.params = { issueKey: 'abc' };
+      mockRequest.body = { transitionId: '2' };
 
-        const response = await request(app).delete('/issues/1');
+      await transitionIssue(mockRequest as Request, mockResponse as Response);
 
-        expect(response.statusCode).toBe(500);
-        expect(response.body.message).toBe('Simulated database error');
-        expect(mockExec).toHaveBeenCalledWith('ROLLBACK');
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Invalid issue key format.  Must be a number.' });
+    });
+
+    it('should return 500 if transition fails', async () => {
+      (issueService.transitionIssue as jest.Mock).mockRejectedValue(new Error('Failed to transition issue'));
+      mockRequest.params = { issueKey: '1' };
+      mockRequest.body = { transitionId: '2' };
+
+      await transitionIssue(mockRequest as Request, mockResponse as Response);
+
+      expect(issueService.transitionIssue).toHaveBeenCalledWith('1', mockRequest.body);
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Failed to transition issue' });
     });
   });
 });


### PR DESCRIPTION
Adds unit tests for the issue controller, ensuring all API endpoints are covered for success and error scenarios. This includes tests for createIssue, getIssue, updateIssue, deleteIssue, and transitionIssue.