### PR TITLE
ATM-884: Implement webhook route handlers

### DIFF
--- a/src/api/routes/webhook.routes.ts
+++ b/src/api/routes/webhook.routes.ts
@@ -1,8 +1,37 @@
-import express from 'express';
-import { triggerWebhook } from '../api/controllers/webhook.controller';
+// src/api/routes/webhook.routes.ts
+import express, { Request, Response } from 'express';
+import { registerWebhook, deleteWebhook, listWebhooks } from '../controllers/webhook.controller';
 
 const router = express.Router();
 
-router.post('/webhooks', triggerWebhook);
+// POST /webhooks - Register a new webhook
+router.post('/webhooks', async (req: Request, res: Response) => {
+  try {
+    await registerWebhook(req, res);
+  } catch (error) {
+    console.error('Error registering webhook:', error);
+    res.status(500).json({ error: 'Failed to register webhook' });
+  }
+});
+
+// DELETE /webhooks/:webhookId - Delete a webhook
+router.delete('/webhooks/:webhookId', async (req: Request, res: Response) => {
+  try {
+    await deleteWebhook(req, res);
+  } catch (error) {
+    console.error('Error deleting webhook:', error);
+    res.status(500).json({ error: 'Failed to delete webhook' });
+  }
+});
+
+// GET /webhooks - List all registered webhooks
+router.get('/webhooks', async (req: Request, res: Response) => {
+  try {
+    await listWebhooks(req, res);
+  } catch (error) {
+    console.error('Error listing webhooks:', error);
+    res.status(500).json({ error: 'Failed to list webhooks' });
+  }
+});
 
 export default router;


### PR DESCRIPTION
Implemented route handlers for webhook API endpoints as defined in ATM-884.

This includes:
- POST /webhooks: Register a new webhook
- DELETE /webhooks/:webhookId: Delete a webhook
- GET /webhooks: List all registered webhooks