### PR TITLE
ATM-956: Define Schema for Boards Table

### DIFF
--- a/src/db/boards.sql
+++ b/src/db/boards.sql
@@ -1,0 +1,6 @@
+-- Define schema for Boards table
+CREATE TABLE boards (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    board_name TEXT NOT NULL,
+    board_type TEXT
+);


### PR DESCRIPTION
Defines the schema for the Boards table.

This includes the following:

- `id` (INTEGER, PRIMARY KEY, AUTOINCREMENT)
- `board_name` (TEXT, NOT NULL)
- `board_type` (TEXT)

This fulfills the requirements of issue ATM-956.