### PR TITLE
ATM-960: Define Schema for Attachments Table

### DIFF
--- a/src/db/attachments.sql
+++ b/src/db/attachments.sql
@@ -1,0 +1,9 @@
+-- Define the schema for the Attachments table
+CREATE TABLE Attachments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id INTEGER NOT NULL,
+    filename TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    created_at TIMESTAMP,
+    FOREIGN KEY (issue_id) REFERENCES Issues(id)
+);


### PR DESCRIPTION
Defines the schema for the Attachments table.

This commit defines the SQL schema for the `Attachments` table, including data types, primary and foreign keys, and not-null constraints as specified in the issue description (ATM-960).