### PR TITLE
ATM-962: Define Schema for Epics Table

### DIFF
--- a/src/db/epics.sql
+++ b/src/db/epics.sql
@@ -1,0 +1,7 @@
+-- Define the schema for the Epics table
+CREATE TABLE IF NOT EXISTS epics (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    epic_key TEXT UNIQUE NOT NULL,
+    epic_name TEXT NOT NULL,
+    epic_description TEXT
+);


### PR DESCRIPTION
Defines the schema for the `epics` table in the database. This includes the necessary data types, primary key, unique constraints, and not-null constraints as specified in the issue ATM-962.