### PR TITLE
ATM-972: Define API endpoint for Add attachment - POST /issues/:issueKey/attachments

### DIFF
--- a/src/api/controllers/issue.controller.ts
+++ b/src/api/controllers/issue.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { issueService } from '../services/issue.service';
 import { validationResult } from 'express-validator';
 import multer from 'multer';
+import * as fs from 'fs/promises';
 
 export const issueController = {
   async getIssue(req: Request, res: Response) {
@@ -30,23 +31,37 @@ export const issueController = {
       }
 
       const issueKey = req.params.issueKey;
-      const upload = multer({ dest: 'uploads/' });
+      const upload = multer({ dest: 'uploads/', limits: { fileSize: 10 * 1024 * 1024 } }); // 10MB limit
       upload.single('attachment')(req, res, async (err: any) => {
         if (err) {
           console.error('File upload error:', err);
+          if (err instanceof multer.MulterError) {
+            if (err.code === 'LIMIT_FILE_SIZE') {
+              return res.status(400).json({ message: 'File size exceeds the limit' });
+            }
+          }
           return res.status(400).json({ message: 'File upload error' });
         }
         if (!req.file) {
           return res.status(400).json({ message: 'No file uploaded' });
         }
         const filePath = req.file.path;
+        const originalname = req.file.originalname;
+        const mimetype = req.file.mimetype;
         // Process the file (e.g., save to database, etc.)
         try{
-          const attachmentId = await issueService.addAttachment(issueKey, filePath);
-          res.status(200).json({ message: 'Attachment uploaded successfully', attachmentId });
+          const attachmentId = await issueService.addAttachment(issueKey, filePath, originalname, mimetype);
+          res.status(200).json({ message: 'Attachment uploaded successfully', attachmentId, filename: originalname, mimetype });
         } catch (error:any) {
           console.error('Error adding attachment:', error);
           res.status(500).json({ message: error.message || 'Internal server error' });
+        } finally {
+           // Clean up the temporary file
+           try {
+             await fs.unlink(filePath);
+           } catch (unlinkError) {
+             console.error('Error deleting temporary file:', unlinkError);
+           }
         }
       });
     } catch (error: any) {

--- a/src/api/services/issue.service.ts
+++ b/src/api/services/issue.service.ts
@@ -13,22 +13,15 @@ export const issueService = {
     }
   },
 
-  async addAttachment(issueKey: string, filePath: string): Promise<number> {
+  async addAttachment(issueKey: string, filePath: string, originalname: string, mimetype: string): Promise<number> {
     try {
       const fileContent = await fs.readFile(filePath);
-      const insert = db.prepare('INSERT INTO attachments (issue_key, file_name, file_content) VALUES (?, ?, ?)');
-      const info = insert.run(issueKey, filePath.split('/').pop(), fileContent);
+      const insert = db.prepare('INSERT INTO attachments (issue_key, file_name, file_content, mimetype) VALUES (?, ?, ?, ?)');
+      const info = insert.run(issueKey, originalname, fileContent, mimetype);
       return info.lastInsertRowid as number;
     } catch (error: any) {
       console.error('Error adding attachment:', error);
       throw new Error(error.message || 'Failed to add attachment');
-    } finally {
-      // Clean up the temporary file
-      try {
-        await fs.unlink(filePath);
-      } catch (unlinkError) {
-        console.error('Error deleting temporary file:', unlinkError);
-      }
-    }
+    } 
   }
 };


### PR DESCRIPTION
This pull request implements the API endpoint for adding attachments to issues. It includes:

- Defining the POST /issues/:issueKey/attachments endpoint.
- Using the issue key as a path parameter.
- Implementing file upload using `multer` with a file size limit of 10MB.
- Handling file upload errors, including file size exceeded errors.
- Defining the response format for successful and failed uploads, including attachment metadata.
- Cleaning up temporary files after upload.

This resolves issue ATM-972.