### PR TITLE
ATM-953: Write SQL Script to Insert Initial Data

### DIFF
--- a/src/db/insert_initial_data.sql
+++ b/src/db/insert_initial_data.sql
@@ -1,0 +1,19 @@
+-- Insert default boards
+INSERT INTO Boards (name) VALUES ('To Do');
+INSERT INTO Boards (name) VALUES ('In Progress');
+INSERT INTO Boards (name) VALUES ('Done');
+
+-- Insert default issue types (assuming an IssueTypes table exists)
+-- Replace with the actual table and column names if different
+INSERT INTO IssueTypes (name) VALUES ('Task');
+INSERT INTO IssueTypes (name) VALUES ('Subtask');
+INSERT INTO IssueTypes (name) VALUES ('Story');
+INSERT INTO IssueTypes (name) VALUES ('Bug');
+INSERT INTO IssueTypes (name) VALUES ('Epic');
+
+-- Insert default transitions (assuming a Transitions table exists)
+-- Replace with the actual table and column names if different and adjust board/issue type IDs
+INSERT INTO Transitions (fromBoard, toBoard, name) VALUES ((SELECT id FROM Boards WHERE name = 'To Do'), (SELECT id FROM Boards WHERE name = 'In Progress'), 'To Do -> In Progress');
+INSERT INTO Transitions (fromBoard, toBoard, name) VALUES ((SELECT id FROM Boards WHERE name = 'In Progress'), (SELECT id FROM Boards WHERE name = 'Done'), 'In Progress -> Done');
+INSERT INTO Transitions (fromBoard, toBoard, name) VALUES ((SELECT id FROM Boards WHERE name = 'To Do'), (SELECT id FROM Boards WHERE name = 'Done'), 'To Do -> Done');
+INSERT INTO Transitions (fromBoard, toBoard, name) VALUES ((SELECT id FROM Boards WHERE name = 'In Progress'), (SELECT id FROM Boards WHERE name = 'To Do'), 'In Progress -> To Do');


### PR DESCRIPTION
Created SQL script to insert initial data for boards, issue types, and transitions. The script includes INSERT statements for default values and is executable against an SQLite database. The script also includes comments.  

Initial Data Inserted:
- Default boards: To Do, In Progress, Done
- Default issue types: Task, Subtask, Story, Bug, Epic
- Default transitions: To Do -> In Progress, In Progress -> Done, To Do -> Done, In Progress -> To Do