### PR TITLE
ATM-959: Define Schema for Users Table

### DIFF
--- a/src/db/users.sql
+++ b/src/db/users.sql
@@ -1,0 +1,6 @@
+-- Define the schema for the Users table
+CREATE TABLE Users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_key TEXT UNIQUE NOT NULL,
+  display_name TEXT
+);


### PR DESCRIPTION
Defines the schema for the Users table, as specified in ATM-959.  The SQL script creates a table named `Users` with the following columns:

- `id`: INTEGER, PRIMARY KEY, AUTOINCREMENT
- `user_key`: TEXT, UNIQUE, NOT NULL
- `display_name`: TEXT

This fulfills all acceptance criteria of the task.