### PR TITLE
ATM-1071: Fix: signoff.test.ts - Missing imports

### DIFF
--- a/src/signoff/signoff.test.ts
+++ b/src/signoff/signoff.test.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '../../src/config/config.service'; // Corrected import path
 import { SignoffService } from './signoff.service';
+import { jest } from '@jest/globals'; // Or just 'jest' depending on your setup
+
 
 describe('SignoffService', () => {
     let service: SignoffService;
@@ -17,7 +19,7 @@ describe('SignoffService', () => {
                         get: jest.fn((key: string) => {
                             if (key === 'someConfigKey') {
                                 return 'mockConfigValue';
-                            } 
+                            }
                             return undefined;
                         }),
                     },


### PR DESCRIPTION
Fix missing imports in signoff.test.ts. Specifically, added the import for `jest` from `@jest/globals` to ensure the test file is portable and avoids potential issues with testing environments.