### PR TITLE
ATM-1072: Fix: webhook.controller.test.ts - Missing imports

### DIFF
--- a/src/api/controllers/webhook.controller.test.ts
+++ b/src/api/controllers/webhook.controller.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import { Express } from 'express';
 import { setupApp } from '../../../src/app';
 import * as webhookService from '../../services/webhook.service'; // Import as a namespace
+import { jest, expect } from '@jest/globals';
 
 describe('Webhook Controller', () => {
     let app: Express;


### PR DESCRIPTION
Fixes missing imports in `webhook.controller.test.ts` by adding explicit imports for `jest` and `expect` from `@jest/globals`. This ensures the test file has all necessary dependencies declared.