### PR TITLE
ATM-1106: Implement Issue Linking Route

### DIFF
--- a/src/api/routes/issueLinkRoutes.ts
+++ b/src/api/routes/issueLinkRoutes.ts
@@ -1,0 +1,8 @@
+import { Router, Request, Response } from 'express';
+import * as issueController from '../controllers/issueController';
+
+const router = Router();
+
+router.post('/', issueController.linkIssues);
+
+export default router;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response, NextFunction } from 'express';
 import bodyParser from 'body-parser';
 import { issueRoutes } from './api/routes/issueRoutes';
+import issueLinkRoutes from './api/routes/issueLinkRoutes';
 import { errorHandler } from './api/middleware/errorHandler';
 import { requestLogger } from './api/middleware/requestLogger';
 import multer from 'multer';
@@ -15,6 +16,7 @@ app.use(bodyParser.json());
 app.use(requestLogger);
 
 app.use('/rest/api/3/issue', issueRoutes);
+app.use('/rest/api/3/issueLink', issueLinkRoutes);
 
 app.use(errorHandler);
 


### PR DESCRIPTION
Implements the issue linking route as per ATM-1106.

- Created `src/api/routes/issueLinkRoutes.ts`.
- Defined route `POST /` -> `issueController.linkIssues` in the new router.
- Mounted the route in `src/app.ts` under the `/rest/api/3/issueLink` path.