### PR TITLE
ATM-1107: Update JSON Transformer

### DIFF
--- a/src/utils/jsonTransformer.ts
+++ b/src/utils/jsonTransformer.ts
@@ -1,4 +1,4 @@
-import { Issue } from '../api/models/issue';
+import { Issue } from '../models/issue';
 import { Attachment } from '../api/models/attachment';
 import { db } from '../config/db';
 
@@ -9,8 +9,67 @@ interface IssueResponse {
     fields: {
         summary: string;
         assignee?: any;
+        issuelinks?: any[];
         [key: string]: any;
     };
+}
+
+interface IssueLink {
+    id: number;
+    link_type: string;
+    source_issue_id: number;
+    target_issue_id: number;
+}
+
+interface LinkedIssueDetails {
+    id: number;
+    key: string;
+    self: string;
+    fields: {
+        summary: string;
+        status: {
+            name: string;
+        };
+        issuetype: {
+            name: string;
+        };
+    };
+}
+
+async function fetchIssueDetails(issueId: number): Promise<LinkedIssueDetails | null> {
+    return new Promise((resolve, reject) => {
+        db.get<any>(
+            'SELECT id, key, summary, status, issuetype FROM Issues WHERE id = ?', // Assuming 'status' and 'issuetype' are stored directly in the Issues table.
+            [issueId],
+            (err, row) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+
+                if (!row) {
+                    resolve(null);
+                    return;
+                }
+
+                const issueDetails: LinkedIssueDetails = {
+                    id: row.id,
+                    key: row.key,
+                    self: `/rest/api/3/issue/${row.key}`,
+                    fields: {
+                        summary: row.summary,
+                        status: {
+                            name: row.status,
+                        },
+                        issuetype: {
+                            name: row.issuetype,
+                        },
+                    },
+                };
+                resolve(issueDetails);
+            }
+        );
+    });
 }
 
 export async function formatIssueResponse(issue: Issue): Promise<IssueResponse> {
@@ -59,6 +118,50 @@ export async function formatIssueResponse(issue: Issue): Promise<IssueResponse> 
         }));
     } else {
         issueResponse.fields.attachment = [];
+    }
+
+    // Fetch issue links
+    const issueLinks: IssueLink[] = await new Promise((resolve, reject) => {
+        db.all<IssueLink[]>(
+            'SELECT id, link_type, source_issue_id, target_issue_id FROM IssueLinks WHERE source_issue_id = ? OR target_issue_id = ?',
+            [issue.id, issue.id],
+            (err, rows) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve(rows);
+            }
+        );
+    });
+
+    if (issueLinks && issueLinks.length > 0) {
+        issueResponse.fields.issuelinks = [];
+        for (const link of issueLinks) {
+            const linkedIssueId = link.source_issue_id === issue.id ? link.target_issue_id : link.source_issue_id;
+
+            const linkedIssueDetails = await fetchIssueDetails(linkedIssueId);
+
+            if (linkedIssueDetails) {
+                const linkDetails: any = {
+                    id: link.id,
+                    self: `/rest/api/3/issueLink/${link.id}`,
+                    type: {
+                        name: link.link_type, // Assuming link_type directly reflects the link type name
+                    },
+                };
+
+                if (link.source_issue_id === issue.id) {
+                    linkDetails.outwardIssue = linkedIssueDetails;
+                } else {
+                    linkDetails.inwardIssue = linkedIssueDetails;
+                }
+
+                issueResponse.fields.issuelinks.push(linkDetails);
+            }
+        }
+    } else {
+        issueResponse.fields.issuelinks = [];
     }
 
     return issueResponse;


### PR DESCRIPTION
This pull request updates the JSON Transformer to include issue link details.

It modifies the `formatIssueResponse` function to fetch and include issue link details:

*   Queries the `IssueLinks` table for links where the current issue's ID is either `source_issue_id` or `target_issue_id`.  
*   For each link found, fetch the details of the *other* issue involved in the link (key, summary, status, issuetype).  
*   Adds an `issuelinks` array field within `fields`. Each element in the array represents a link and follows the Jira structure.