### PR TITLE
ATM-1113: Implement Create Metadata Endpoint

### DIFF
--- a/src/api/controllers/metadataController.ts
+++ b/src/api/controllers/metadataController.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction, Router } from 'express';
+
+const getCreateMetadata = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const metadata = {
+      projects: [
+        {
+          id: '10000',
+          name: 'My Project',
+          issuetypes: [
+            {
+              id: '10001',
+              name: 'Task',
+              subtask: false
+            },
+            {
+              id: '10002',
+              name: 'Subtask',
+              subtask: true
+            },
+            {
+              id: '10003',
+              name: 'Story',
+              subtask: false
+            },
+            {
+              id: '10004',
+              name: 'Bug',
+              subtask: false
+            },
+            {
+              id: '10005',
+              name: 'Epic',
+              subtask: false
+            }
+          ]
+        }
+      ]
+    };
+
+    res.setHeader('Content-Type', 'application/json');
+    res.status(200).json(metadata);
+  } catch (error: any) {
+    console.error('Error creating metadata:', error);
+    res.status(500).json({ error: 'Failed to create metadata' });
+  }
+};
+
+export { getCreateMetadata };

--- a/src/api/routes/metadataRoutes.ts
+++ b/src/api/routes/metadataRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getCreateMetadata } from '../api/controllers/metadataController';
+
+const router = Router();
+
+router.get('/createmeta', getCreateMetadata);
+
+export default router;

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { requestLogger } from './api/middleware/requestLogger';
 import issueRoutes from './api/routes/issueRoutes';
 import issueLinkRoutes from './api/routes/issueLinkRoutes';
 import epicRoutes from './api/routes/epicRoutes';
+import metadataRoutes from './api/routes/metadataRoutes';
 
 const app = express();
 
@@ -16,6 +17,7 @@ app.use('/rest/api/3/issue', issueRoutes);
 app.use('/rest/api/3/issue-link', issueLinkRoutes);
 app.use('/rest/api/3/epic', epicRoutes);
 app.use('/rest/api/3/search', issueRoutes);
+app.use('/rest/api/3/issue', metadataRoutes);
 
 // Error handling middleware.  Must be the last middleware.
 app.use(errorHandler);


### PR DESCRIPTION
Implements the Create Metadata Endpoint as per ATM-1113. This includes creating a Metadata Controller with a `getCreateMetadata` method, constructing a static JSON response, sending a 200 OK response, creating Metadata Routes with an Express router, and mounting the router in `src/app.ts` under the `/rest/api/3/issue` path.