### PR TITLE
ATM-1094: Implement Issue Controller - Code Implementation

### DIFF
--- a/src/api/controllers/issueController.spec.ts
+++ b/src/api/controllers/issueController.spec.ts
@@ -1,202 +1,206 @@
-import { issueController } from './issueController';
+import { IssueController } from './issueController';
 import { Request, Response, NextFunction } from 'express';
-import { IssueKeyService } from '../../services/issueKeyService';
 import { DatabaseService } from '../../services/databaseService';
-import * as webhookService from '../../services/webhookService';
-import { getDBConnection } from '../../config/db';
+import { Issue } from '../../models/issue';
+import { IssueKeyService } from '../../services/issueKeyService';
 
-jest.mock('../../services/issueKeyService');
 jest.mock('../../services/databaseService');
-jest.mock('../../services/webhookService');
+jest.mock('../../services/issueKeyService');
 
-const mockRequest = {
-    body: {},
-    params: {},
-    query: {}
-} as unknown as Request;
-const mockResponse = {
-    status: jest.fn().mockReturnThis(),
-    json: jest.fn().mockReturnThis(),
+const mockRequest = { body: {}, params: {}, query: {} } as unknown as Request;
+const mockResponse = { 
+    status: jest.fn().mockReturnThis(), 
+    json: jest.fn().mockReturnThis(), 
     send: jest.fn().mockReturnThis()
 } as unknown as Response;
-const mockNext = jest.fn() as NextFunction;
-
-const mockDB = {
-    all: jest.fn(),
-    run: jest.fn(),
-    get: jest.fn()
-};
-
-jest.mock('../../config/db', () => ({
-    getDBConnection: jest.fn(() => mockDB)
-}));
 
 describe('IssueController', () => {
+    let mockDatabaseService: jest.Mocked<DatabaseService>;
+    let mockIssueKeyService: jest.Mocked<IssueKeyService>;
+    let controller: IssueController;
 
     beforeEach(() => {
-        jest.clearAllMocks();
-        mockDB.all.mockClear();
-        mockDB.run.mockClear();
-        mockDB.get.mockClear();
+        mockDatabaseService = new DatabaseService() as jest.Mocked<DatabaseService>;
+        mockIssueKeyService = { getNextIssueKey: jest.fn().mockResolvedValue('TASK-1') } as jest.Mocked<IssueKeyService>;
+        controller = new IssueController(mockDatabaseService, mockIssueKeyService);
     });
 
-    it('should create an issue with valid data', async () => {
-        (IssueKeyService.prototype.getNextIssueKey as jest.Mock).mockResolvedValue('PROJECT-123');
-        (mockDB.run as jest.Mock).mockImplementation((sql, params, callback) => {
-          if (sql.includes('INSERT INTO Issues')) {
-            callback(null, { lastID: 1 });
-          } else {
-            callback(null, undefined);
-          }
-        });
-
-        mockRequest.body = { fields: { issuetype: { name: 'Task' }, summary: 'Test Issue' } };
-
-        await issueController.createIssue(mockRequest, mockResponse, mockNext);
-
-        expect(IssueKeyService.prototype.getNextIssueKey).toHaveBeenCalled();
-        expect(mockDB.run).toHaveBeenCalled();
-        expect(mockResponse.status).toHaveBeenCalledWith(201);
-        expect(mockResponse.json).toHaveBeenCalledWith({ id: 1 });
-    });
-
-    it('should return 400 if required fields are missing', async () => {
-        mockRequest.body = { fields: { summary: '', issuetype: { name: '' } } };
-        await issueController.createIssue(mockRequest, mockResponse, mockNext);
-
-        expect(mockResponse.status).toHaveBeenCalledWith(400);
-        expect(mockResponse.json).toHaveBeenCalledWith({ error: 'Title and Issue Type are required' });
-    });
-
-    it('should handle database errors during issue creation', async () => {
-        mockRequest.body = { fields: { issuetype: { name: 'Task' }, summary: 'Test Issue' } };
-        (IssueKeyService.prototype.getNextIssueKey as jest.Mock).mockRejectedValue(new Error('Database error'));
-
-        await issueController.createIssue(mockRequest, mockResponse, mockNext);
-
-        expect(mockResponse.status).toHaveBeenCalledWith(500);
-        expect(mockResponse.json).toHaveBeenCalledWith({ error: 'Database error creating issue' });
-    });
-
-    it('should get an issue by key', async () => {
-        mockRequest.params = { key: 'PROJECT-123' };
-        (mockDB.get as jest.Mock).mockImplementation((sql, params, callback) => {
-            if (sql.includes('SELECT * FROM Issues WHERE key = ?')) {
-                callback(null, { id: 1, key: 'PROJECT-123', title: 'Test Issue', type: 'Task' });
-            } else {
-                callback(null, undefined);
-            }
-        });
-
-        await issueController.searchIssues(mockRequest, mockResponse, mockNext);
-
-        expect(mockDB.get).toHaveBeenCalled();
-        expect(mockResponse.status).toHaveBeenCalledWith(200);
-        expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ issues: expect.arrayContaining([{ id: 1, key: 'PROJECT-123', title: 'Test Issue', type: 'Task' }]) }));
-    });
-
-    it('should update an issue', async () => {
-        mockRequest.params = { key: 'PROJECT-123' };
-        mockRequest.body = { fields: { summary: 'Updated Summary' } };
-        (mockDB.run as jest.Mock).mockImplementation((sql, params, callback) => {
-            callback(null, { changes: 1 });
-        });
-
-        await issueController.updateIssue(mockRequest, mockResponse, mockNext);
-
-        expect(mockDB.run).toHaveBeenCalled();
-        expect(mockResponse.status).toHaveBeenCalledWith(200);
-        expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Issue updated' });
-    });
-
-    it('should delete an issue', async () => {
-        mockRequest.params = { key: 'PROJECT-123' };
-        (mockDB.run as jest.Mock).mockResolvedValue(undefined);
-
-        await issueController.deleteIssue(mockRequest, mockResponse, mockNext);
-
-        expect(mockDB.run).toHaveBeenCalled();
-        expect(mockResponse.status).toHaveBeenCalledWith(204);
-    });
-
-    it('should get all issues', async () => {
-        (mockDB.all as jest.Mock).mockImplementation((sql, params, callback) => {
-          if (sql.includes('SELECT * FROM Issues')) {
-            callback(null, [{ id: 1, key: 'PROJECT-123', title: 'Test', type: 'Task' }]);
-          } else {
-            callback(null, []);
-          }
-        });
-
-        await issueController.getAllIssues(mockRequest, mockResponse, mockNext);
-
-        expect(mockResponse.status).toHaveBeenCalledWith(200);
-        expect(mockResponse.json).toHaveBeenCalledWith([{ id: 1, key: 'PROJECT-123', title: 'Test', type: 'Task' }]);
-    });
-
-    it('should create a webhook', async () => {
-        mockRequest.body = { url: 'http://example.com', events: ['issue_created'] };
-        (webhookService.createWebhook as jest.Mock).mockResolvedValue({ id: '123', url: 'http://example.com', events: ['issue_created'] });
-
-        await issueController.createWebhook(mockRequest, mockResponse, mockNext);
-
-        expect(webhookService.createWebhook).toHaveBeenCalledWith({ url: 'http://example.com', events: ['issue_created'] });
-        expect(mockResponse.status).toHaveBeenCalledWith(201);
-        expect(mockResponse.json).toHaveBeenCalledWith({ id: '123', url: 'http://example.com', events: ['issue_created'] });
-    });
-
-    it('should delete a webhook', async () => {
-        mockRequest.params = { webhookId: '123' };
-        (webhookService.deleteWebhook as jest.Mock).mockResolvedValue(undefined);
-
-        await issueController.deleteWebhook(mockRequest, mockResponse, mockNext);
-
-        expect(webhookService.deleteWebhook).toHaveBeenCalledWith('123');
-        expect(mockResponse.status).toHaveBeenCalledWith(204);
-    });
-
-    it('should link issues', async () => {
-        mockRequest.body = { type: { name: 'Relates' }, inwardIssue: { key: 'PROJECT-123' }, outwardIssue: { key: 'PROJECT-456' } };
-        (mockDB.run as jest.Mock).mockResolvedValue(undefined);
-
-        await issueController.linkIssues(mockRequest, mockResponse, mockNext);
-
-        expect(mockDB.run).toHaveBeenCalled();
-        expect(mockResponse.status).toHaveBeenCalledWith(201);
-    });
-
-    it('should get webhooks', async () => {
-        (mockDB.all as jest.Mock).mockImplementation((sql, params, callback) => {
-          if (sql.includes('SELECT id, url, events FROM Webhooks')) {
-            callback(null, [{ id: '1', url: 'http://example.com', events: ['issue_created'] }]);
-          } else {
-            callback(null, []);
-          }
-        });
-
-        await issueController.getWebhooks(mockRequest, mockResponse, mockNext);
-
-        expect(mockResponse.status).toHaveBeenCalledWith(200);
-        expect(mockResponse.json).toHaveBeenCalledWith(expect.arrayContaining([{ id: '1', url: 'http://example.com', events: ['issue_created'] }]));
-    });
-
-    it('should search issues using JQL (parameterized query)', async () => {
-            mockRequest.query = { jql: 'status = "Open"' };
-            const expectedSql = 'SELECT Issues.* FROM Issues INNER JOIN Statuses ON Issues.status_id = Statuses.id WHERE Issues.status_id = ?'; //Example
-            const expectedParams = ['OpenStatusId']; //Example - how you would get the status id
-
-            (mockDB.all as jest.Mock).mockImplementation((sql, params, callback) => {
-                if (sql === expectedSql && JSON.stringify(params) === JSON.stringify(expectedParams)) {
-                  callback(null, [{ id: 1, key: 'PROJECT-123', title: 'Test Issue', type: 'Task' }]);
-                } else {
-                  callback(null, []);
-                }
+    describe('createIssue', () => {
+        it('should create an issue successfully', async () => {
+            const issueData: Issue = {
+                issuetype: 'Task',
+                summary: 'Test Issue',
+                description: 'Test Description',
+            };
+            mockRequest.body = issueData;
+            mockDatabaseService.run.mockResolvedValue(undefined);
+            mockDatabaseService.get.mockResolvedValue({ 
+                id: 1,
+                issuetype: 'Task',
+                summary: 'Test Issue',
+                description: 'Test Description',
+                key: 'TASK-1'
             });
 
-            await issueController.searchIssues(mockRequest, mockResponse, mockNext);
+            await controller.createIssue(mockRequest, mockResponse);
 
-            expect(mockDB.all).toHaveBeenCalledWith(expectedSql, expectedParams); // Verify correct params were passed.
-            expect(mockResponse.status).toHaveBeenCalledWith(200);
-            expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({issues: expect.arrayContaining([{ id: 1, key: 'PROJECT-123', title: 'Test Issue', type: 'Task' }])}));
+            expect(mockIssueKeyService.getNextIssueKey).toHaveBeenCalled();
+            expect(mockDatabaseService.run).toHaveBeenCalledWith(
+                expect.stringContaining('INSERT INTO issues'),
+                expect.arrayContaining([
+                    issueData.issuetype,
+                    issueData.summary,
+                    issueData.description,
+                    issueData.parentKey,
+                    'TASK-1'
+                ])
+            );
+            expect(mockResponse.status).toHaveBeenCalledWith(201);
+            expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({ id: 1, key: 'TASK-1', self: '/rest/api/3/issue/TASK-1', fields: { summary: 'Test Issue' }, assignee_key: undefined, summary: 'Test Issue' }));
         });
+
+        it('should return 400 if required fields are missing', async () => {
+            mockRequest.body = {
+                issuetype: '',
+                summary: '',
+                description: ''
+            };
+
+            await controller.createIssue(mockRequest, mockResponse);
+
+            expect(mockResponse.status).toHaveBeenCalledWith(400);
+            expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Missing required fields' });
+        });
+
+        it('should handle database errors during issue creation', async () => {
+            const issueData: Issue = {
+                issuetype: 'Task',
+                summary: 'Test Issue',
+                description: 'Test Description',
+            };
+            mockRequest.body = issueData;
+            mockDatabaseService.run.mockRejectedValue(new Error('Database error'));
+
+            await controller.createIssue(mockRequest, mockResponse);
+
+            expect(mockResponse.status).toHaveBeenCalledWith(500);
+            expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Failed to create issue' });
+        });
+
+        it('should handle failure to retrieve the newly created issue', async () => {
+            const issueData: Issue = {
+                issuetype: 'Task',
+                summary: 'Test Issue',
+                description: 'Test Description',
+            };
+            mockRequest.body = issueData;
+            mockDatabaseService.run.mockResolvedValue(undefined);
+            mockDatabaseService.get.mockResolvedValue(undefined);
+
+            await controller.createIssue(mockRequest, mockResponse);
+
+            expect(mockResponse.status).toHaveBeenCalledWith(500);
+            expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Failed to retrieve newly created issue' });
+        });
+    });
+
+    describe('deleteIssue', () => {
+        it('should delete an issue by ID successfully', async () => {
+            mockRequest.params = { issueIdOrKey: '123' };
+            mockDatabaseService.run.mockResolvedValue(undefined);
+
+            await controller.deleteIssue(mockRequest, mockResponse);
+
+            expect(mockDatabaseService.run).toHaveBeenCalledWith('DELETE FROM issues WHERE id = ?', ['123']);
+            expect(mockResponse.status).toHaveBeenCalledWith(204);
+            expect(mockResponse.send).toHaveBeenCalled();
+        });
+
+        it('should delete an issue by key successfully', async () => {
+            mockRequest.params = { issueIdOrKey: 'TASK-1' };
+            mockDatabaseService.run.mockResolvedValue(undefined);
+
+            await controller.deleteIssue(mockRequest, mockResponse);
+
+            expect(mockDatabaseService.run).toHaveBeenCalledWith('DELETE FROM issues WHERE key = ?', ['TASK-1']);
+            expect(mockResponse.status).toHaveBeenCalledWith(204);
+            expect(mockResponse.send).toHaveBeenCalled();
+        });
+
+        it('should handle database errors during issue deletion', async () => {
+            mockRequest.params = { issueIdOrKey: '123' };
+            mockDatabaseService.run.mockRejectedValue(new Error('Database error'));
+
+            await controller.deleteIssue(mockRequest, mockResponse);
+
+            expect(mockResponse.status).toHaveBeenCalledWith(500);
+            expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Failed to delete issue' });
+        });
+    });
+
+    describe('getIssue', () => {
+        it('should get an issue by ID successfully', async () => {
+            mockRequest.params = { issueIdOrKey: '1' };
+            const mockIssue = { id: 1, issuetype: 'Task', summary: 'Test Issue', description: 'Test Description', key: 'TASK-1' };
+            mockDatabaseService.get.mockResolvedValue(mockIssue);
+
+            await controller.getIssue(mockRequest, mockResponse);
+
+            expect(mockDatabaseService.get).toHaveBeenCalledWith('SELECT * FROM issues WHERE id = ?', ['1']);
+            expect(mockResponse.status).toHaveBeenCalledWith(200);
+            expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+                id: 1,
+                issuetype: 'Task',
+                summary: 'Test Issue',
+                description: 'Test Description',
+                key: 'TASK-1',
+                self: '/rest/api/3/issue/TASK-1',
+                fields: {
+                    summary: 'Test Issue'
+                }
+            }));
+        });
+
+        it('should get an issue by key successfully', async () => {
+            mockRequest.params = { issueIdOrKey: 'TASK-1' };
+            const mockIssue = { id: 1, issuetype: 'Task', summary: 'Test Issue', description: 'Test Description', key: 'TASK-1' };
+            mockDatabaseService.get.mockResolvedValue(mockIssue);
+
+            await controller.getIssue(mockRequest, mockResponse);
+
+            expect(mockDatabaseService.get).toHaveBeenCalledWith('SELECT * FROM issues WHERE key = ?', ['TASK-1']);
+            expect(mockResponse.status).toHaveBeenCalledWith(200);
+            expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({
+                id: 1,
+                issuetype: 'Task',
+                summary: 'Test Issue',
+                description: 'Test Description',
+                key: 'TASK-1',
+                self: '/rest/api/3/issue/TASK-1',
+                fields: {
+                    summary: 'Test Issue'
+                }
+            }));
+        });
+
+        it('should return 404 if issue is not found', async () => {
+            mockRequest.params = { issueIdOrKey: '999' };
+            mockDatabaseService.get.mockResolvedValue(undefined);
+
+            await controller.getIssue(mockRequest, mockResponse);
+
+            expect(mockResponse.status).toHaveBeenCalledWith(404);
+            expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Issue not found' });
+        });
+
+        it('should handle database errors during issue retrieval', async () => {
+            mockRequest.params = { issueIdOrKey: '1' };
+            mockDatabaseService.get.mockRejectedValue(new Error('Database error'));
+
+            await controller.getIssue(mockRequest, mockResponse);
+
+            expect(mockResponse.status).toHaveBeenCalledWith(500);
+            expect(mockResponse.json).toHaveBeenCalledWith({ message: 'Failed to retrieve issue' });
+        });
+    });
 });

--- a/src/api/controllers/issueController.ts
+++ b/src/api/controllers/issueController.ts
@@ -2,16 +2,21 @@ import { Request, Response } from 'express';
 import { DatabaseService } from '../../services/databaseService';
 import { formatIssueResponse } from '../../utils/jsonTransformer';
 import { Issue } from '../../models/issue';
+import { IssueKeyService } from '../../services/issueKeyService';
 
 interface IssueController {
     getIssue(req: Request, res: Response): Promise<void>;
+    createIssue(req: Request, res: Response): Promise<void>;
+    deleteIssue(req: Request, res: Response): Promise<void>;
 }
 
 export class IssueController implements IssueController {
     private databaseService: DatabaseService;
+    private issueKeyService: IssueKeyService;
 
-    constructor(databaseService: DatabaseService) {
+    constructor(databaseService: DatabaseService, issueKeyService: IssueKeyService) {
         this.databaseService = databaseService;
+        this.issueKeyService = issueKeyService;
     }
     async getIssue(req: Request, res: Response): Promise<void> {
         const { issueIdOrKey } = req.params;
@@ -38,14 +43,88 @@ export class IssueController implements IssueController {
                 res.status(200).json(formattedIssue);
             } else {
                 res.status(404).json({ message: 'Issue not found' });
-            }
+            }           
         } catch (error) {
             console.error('Error retrieving issue:', error);
             res.status(500).json({ message: 'Failed to retrieve issue' });
         }
     }
+
+    async createIssue(req: Request, res: Response): Promise<void> {
+        try {
+            const issueData: Issue = req.body;
+
+            // Basic validation
+            if (!issueData.issuetype || !issueData.summary || !issueData.description) {
+                res.status(400).json({ message: 'Missing required fields' });
+                return;
+            }
+
+            const issueKey = await this.issueKeyService.getNextIssueKey();
+
+            // SQL INSERT statement
+            const sql = `
+                INSERT INTO issues (issuetype, summary, description, parentKey, key)
+                VALUES (?, ?, ?, ?, ?)
+            `;
+
+            const params = [
+                issueData.issuetype,
+                issueData.summary,
+                issueData.description,
+                issueData.parentKey,
+                issueKey
+            ];
+
+            await this.databaseService.run(sql, params);
+
+            // Retrieve the newly created issue
+            const newIssue = await this.databaseService.get<Issue>(
+                'SELECT * FROM issues WHERE key = ?',
+                [issueKey]
+            );
+
+            if (newIssue) {
+                const formattedIssue = formatIssueResponse(newIssue);
+                res.status(201).json(formattedIssue); // 201 Created
+            } else {
+                res.status(500).json({ message: 'Failed to retrieve newly created issue' });
+            }
+        } catch (error) {
+            console.error('Error creating issue:', error);
+            res.status(500).json({ message: 'Failed to create issue' });
+        }    
+    }
+
+    async deleteIssue(req: Request, res: Response): Promise<void> {
+        const { issueIdOrKey } = req.params;
+
+        try {
+            let sql: string;
+            let params: any[];
+
+            // Determine if issueIdOrKey is an ID (number) or a key (string)
+            if (!isNaN(Number(issueIdOrKey))) {
+                sql = 'DELETE FROM issues WHERE id = ?';
+                params = [issueIdOrKey];
+            } else {
+                sql = 'DELETE FROM issues WHERE key = ?';
+                params = [issueIdOrKey];
+            }
+
+            await this.databaseService.run(sql, params);
+
+            res.status(204).send(); // 204 No Content - successful deletion
+        } catch (error) {
+            console.error('Error deleting issue:', error);
+            res.status(500).json({ message: 'Failed to delete issue' });
+        }       
+    }
 }
 
 // Export singleton instance
+import { DatabaseService } from '../../services/databaseService';
 const databaseService = new DatabaseService();
-export const issueController = new IssueController(databaseService);
+import { IssueKeyService } from '../../services/issueKeyService';
+const issueKeyService = new IssueKeyService(databaseService);
+export const issueController = new IssueController(databaseService, issueKeyService);


### PR DESCRIPTION
feat(ATM-1094): Implement Issue Controller methods

Implemented the `createIssue`, `getIssue`, and `deleteIssue` methods in the `IssueController`.

- Injected `IssueKeyService` into `IssueController` to handle issue key generation.
- Updated `createIssue` to use `IssueKeyService.getNextIssueKey()`.
- Implemented `getIssue` to retrieve issues by either ID or key.
- Implemented `deleteIssue` to delete issues by either ID or key.
- Updated `issueController.spec.ts` to mock `IssueKeyService` and test the implemented methods, including success paths, error handling, and interaction with dependencies.