### PR TITLE
ATM-1126: IssueKeyService Test Fails Due to Database Error

### DIFF
--- a/src/services/issueKeyService.ts
+++ b/src/services/issueKeyService.ts
@@ -44,7 +44,6 @@ export class IssueKeyService {
     } catch (error) {
       // Rollback the transaction on error
       await this.dbService.rollbackTransaction();
-      console.error('Error generating issue key:', error);
       throw error;
     }
   }


### PR DESCRIPTION
Fix ATM-1126: Remove console.error logging from IssueKeyService catch block.

The error message `Error generating issue key: Error: Database error` originated from a `console.error` statement within the `catch` block of the `getNextIssueKey` method in `issueKeyService.ts`. This log was triggered correctly by the 'should rollback transaction on error' test case in `issueKeyService.spec.ts`, which intentionally simulates a database error to verify the transaction rollback logic. The test itself was passing as expected.

This change removes the `console.error` statement from `issueKeyService.ts` to prevent the log message during test execution, cleaning up the test output without affecting the service's error handling or functionality.