### PR TITLE
ATM-1136: Create unit tests for issueLinkRoutes.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^22.14.1",
         "@types/sqlite3": "^5.1.0",
-        "@types/supertest": "^2.0.0",
+        "@types/supertest": "^2.0.16",
         "jest": "^29.7.0",
         "jest-express": "^1.12.0",
         "jest-mock-req-res": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.14.1",
     "@types/sqlite3": "^5.1.0",
-    "@types/supertest": "^2.0.0",
+    "@types/supertest": "^2.0.16",
     "jest": "^29.7.0",
     "jest-express": "^1.12.0",
     "jest-mock-req-res": "^1.0.2",

--- a/src/api/routes/issueLinkRoutes.spec.ts
+++ b/src/api/routes/issueLinkRoutes.spec.ts
@@ -1,0 +1,36 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import issueLinkRoutes from './issueLinkRoutes';
+import { issueController } from '../controllers/issueController';
+
+// Mock the issueController and its methods
+jest.mock('../controllers/issueController', () => {
+    const mockLinkIssues = jest.fn((req: Request, res: Response, next: NextFunction) => {
+        res.status(200).json({ message: 'linkIssues called' });
+    });
+    return {
+        issueController: {
+            linkIssues: mockLinkIssues,
+        },
+    };
+});
+
+describe('issueLinkRoutes', () => {
+    let app: express.Application;
+
+    beforeEach(() => {
+        app = express();
+        app.use(express.json());
+        app.use('/', issueLinkRoutes);
+    });
+
+    it('POST / should call issueController.linkIssues', async () => {
+        const response = await request(app)
+            .post('/')
+            .send({ issueIdOrKey: '123', linkedIssueKey: '456', linkType: 'relates to' });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.body).toEqual({ message: 'linkIssues called' });
+        expect(issueController.linkIssues).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Implements unit tests for issueLinkRoutes.ts, covering the POST / route and verifying that the issueController.linkIssues function is called correctly. The tests mock the issueController and its linkIssues method using Jest and supertest.