### PR TITLE
ATM-1172: Investigate metadataController.spec.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8206,6 +8206,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8402,6 +8410,17 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {

--- a/src/api/controllers/metadataController.spec.ts
+++ b/src/api/controllers/metadataController.spec.ts
@@ -1,88 +1,139 @@
 import { Request, Response, NextFunction } from 'express';
 import { getCreateMetadata } from './metadataController';
 
+// Mock the console.error to prevent test output pollution and allow assertion
+const originalConsoleError = console.error;
+beforeAll(() => {
+  console.error = jest.fn();
+});
+afterAll(() => {
+  console.error = originalConsoleError; // Restore original console.error
+});
+
+beforeEach(() => {
+  // Reset mocks before each test
+  (console.error as jest.Mock).mockClear();
+});
+
 describe('metadataController', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let mockNext: NextFunction;
+  let statusFn: jest.Mock;
+  let jsonFn: jest.Mock;
+  let setHeaderFn: jest.Mock;
+
+  beforeEach(() => {
+    mockRequest = {};
+    jsonFn = jest.fn();
+    statusFn = jest.fn().mockReturnThis(); // Allows chaining .json()
+    setHeaderFn = jest.fn();
+    mockResponse = {
+      setHeader: setHeaderFn,
+      status: statusFn,
+      json: jsonFn,
+    };
+    mockNext = jest.fn();
+    statusFn.mockClear();
+    jsonFn.mockClear();
+    setHeaderFn.mockClear();
+  });
+
   describe('getCreateMetadata', () => {
-    it('should return 200 OK with metadata on success', () => {
-      const mockRequest = {} as Request;
-      const mockResponse = {
-        setHeader: jest.fn(),
-        status: jest.fn().mockReturnThis(),
-        json: jest.fn(),
-      } as unknown as Response;
-      const mockNext = jest.fn() as NextFunction;
+    it('should return 200 OK with the standard metadata structure on success', () => {
+      getCreateMetadata(mockRequest as Request, mockResponse as Response, mockNext);
 
-      getCreateMetadata(mockRequest, mockResponse, mockNext);
-
-      expect(mockResponse.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
-      expect(mockResponse.status).toHaveBeenCalledWith(200);
-      expect(mockResponse.json).toHaveBeenCalledWith({
+      expect(setHeaderFn).toHaveBeenCalledWith('Content-Type', 'application/json');
+      expect(statusFn).toHaveBeenCalledWith(200);
+      expect(jsonFn).toHaveBeenCalledWith({
         projects: [
           {
             id: '10000',
             name: 'My Project',
             issuetypes: [
-              {
-                id: '10001',
-                name: 'Task',
-                subtask: false
-              },
-              {
-                id: '10002',
-                name: 'Subtask',
-                subtask: true
-              },
-              {
-                id: '10003',
-                name: 'Story',
-                subtask: false
-              },
-              {
-                id: '10004',
-                name: 'Bug',
-                subtask: false
-              },
-              {
-                id: '10005',
-                name: 'Epic',
-                subtask: false
-              }
-            ]
-          }
-        ]
+              { id: '10001', name: 'Task', subtask: false },
+              { id: '10002', name: 'Subtask', subtask: true },
+              { id: '10003', name: 'Story', subtask: false },
+              { id: '10004', name: 'Bug', subtask: false },
+              { id: '10005', name: 'Epic', subtask: false },
+            ],
+          },
+        ],
       });
       expect(mockNext).not.toHaveBeenCalled();
+      expect(console.error).not.toHaveBeenCalled();
     });
 
-    it('should return 500 Internal Server Error on error', () => {
-      // Mock the function to throw an error
-      const originalConsoleError = console.error;
-      console.error = jest.fn(); // Suppress console.error during the test
+    it('should return 500 Internal Server Error if setting header fails', () => {
+      const simulatedError = new Error('Simulated setHeader error');
+      // Mock setHeader to throw an error
+      setHeaderFn.mockImplementationOnce(() => {
+        throw simulatedError;
+      });
 
-      const mockRequest = {} as Request;
-      const mockResponse = {
-        status: jest.fn().mockReturnThis(),
-        json: jest.fn(),
-      } as unknown as Response;
-      const mockNext = jest.fn() as NextFunction;
+      getCreateMetadata(mockRequest as Request, mockResponse as Response, mockNext);
 
-      // Modify the implementation to throw an error for testing purposes.  Normally you would not modify source code to test it.
-      const modifiedGetCreateMetadata = (req: Request, res: Response, next: NextFunction) => {
-        try {
-          throw new Error('Simulated error');
-        } catch (error: any) {
-          console.error('Error creating metadata:', error);
-          res.status(500).json({ error: 'Failed to create metadata' });
-        }
-      };
+      // Verify error handling path
+      expect(statusFn).toHaveBeenCalledWith(500);
+      expect(jsonFn).toHaveBeenCalledWith({ error: 'Failed to create metadata' });
+      expect(console.error).toHaveBeenCalledWith('Error creating metadata:', simulatedError);
+      expect(mockNext).not.toHaveBeenCalled(); // Should not call next on error handled by sending response
 
-      modifiedGetCreateMetadata(mockRequest, mockResponse, mockNext);
+      // Ensure other response methods weren't called successfully *after* the error
+      expect(statusFn).toHaveBeenCalledTimes(1); // Only the error status
+      expect(jsonFn).toHaveBeenCalledTimes(1); // Only the error json
+    });
 
-      expect(mockResponse.status).toHaveBeenCalledWith(500);
-      expect(mockResponse.json).toHaveBeenCalledWith({ error: 'Failed to create metadata' });
+     it('should return 500 Internal Server Error if sending status fails', () => {
+       const simulatedError = new Error('Simulated status error');
+       // Mock status to throw an error after setHeader is called
+       statusFn.mockImplementationOnce(() => {
+         throw simulatedError;
+       });
+
+       getCreateMetadata(mockRequest as Request, mockResponse as Response, mockNext);
+
+       // Verify error handling path
+       expect(setHeaderFn).toHaveBeenCalledWith('Content-Type', 'application/json'); // This should still be called before status
+       expect(statusFn).toHaveBeenCalledWith(200);
+       expect(statusFn).toHaveBeenCalledWith(500);
+       expect(jsonFn).toHaveBeenCalledWith({ error: 'Failed to create metadata' });
+       expect(console.error).toHaveBeenCalledWith('Error creating metadata:', simulatedError);
+       expect(mockNext).not.toHaveBeenCalled();
+
+       // Ensure status and json are called only once, and with the error response
+       expect(statusFn).toHaveBeenCalledTimes(2);
+       expect(jsonFn).toHaveBeenCalledTimes(1);
+     });
+
+    it('should return 500 Internal Server Error if sending JSON fails', () => {
+      const simulatedError = new Error('Simulated json error');
+      // Mock json to throw an error
+      jsonFn.mockImplementationOnce(() => {
+        throw simulatedError;
+      });
+
+      getCreateMetadata(mockRequest as Request, mockResponse as Response, mockNext);
+
+      // Verify error handling path
+      expect(setHeaderFn).toHaveBeenCalledWith('Content-Type', 'application/json');
+      expect(statusFn).toHaveBeenCalledWith(200);
+      expect(statusFn).toHaveBeenCalledWith(500);
+      expect(jsonFn).toHaveBeenCalledWith({ error: 'Failed to create metadata' });
+      expect(console.error).toHaveBeenCalledWith('Error creating metadata:', simulatedError);
       expect(mockNext).not.toHaveBeenCalled();
 
-      console.error = originalConsoleError; // Restore console.error
+      // Ensure status and json are called only once, and with the error response
+      expect(statusFn).toHaveBeenCalledTimes(2);
+      expect(jsonFn).toHaveBeenCalledTimes(1);
     });
+
+    // Note: Testing for "database unavailability", "variations in metadata structure",
+    // or "empty metadata" is not directly applicable to the current static implementation
+    // of getCreateMetadata, as it doesn't interact with a database or dynamic data sources.
+    // The error tests above simulate general internal failures that could occur for various
+    // reasons, including issues that *might* stem from data source problems if the
+    // controller were more complex. If the controller were fetching data, we would mock
+    // the data fetching function to simulate these scenarios (e.g., throw DB error, return empty array, return malformed data).
   });
 });


### PR DESCRIPTION
This pull request addresses issue ATM-1172 by enhancing the test coverage for `metadataController.spec.ts`. The tests now cover scenarios where `setHeader`, `status`, or `json` methods of the response object throw errors, ensuring that the error handling within the `getCreateMetadata` function is robust. Additionally, the tests have been refactored to improve readability and maintainability.