### PR TITLE
ATM-1180: Add JSDoc comments to src/api/controllers/metadataController.ts

### DIFF
--- a/src/api/controllers/metadataController.ts
+++ b/src/api/controllers/metadataController.ts
@@ -1,5 +1,11 @@
 import { Request, Response, NextFunction, Router } from 'express';
 
+/**
+ * @description Gets the metadata for creating issues.
+ * @param {Request} req Express request object
+ * @param {Response} res Express response object
+ * @param {NextFunction} next Express next function
+ */
 const getCreateMetadata = (req: Request, res: Response, next: NextFunction) => {
   try {
     const metadata = {


### PR DESCRIPTION
This pull request adds JSDoc comments to the `getCreateMetadata` function in `src/api/controllers/metadataController.ts` to improve code readability and maintainability. Addresses issue ATM-1180.