### PR TITLE
ATM-1186: errorHandler.spec.ts: Property 'statusCode' and 'errors' do not exist on type 'Error'

### DIFF
--- a/src/api/middleware/customError.ts
+++ b/src/api/middleware/customError.ts
@@ -1,0 +1,69 @@
+/**
+ * @file Defines the CustomError class for handling application-specific errors
+ * with status codes and optional detailed error objects.
+ */
+
+/**
+ * Interface for the optional 'errors' object within CustomError.
+ * Allows for structured error details.
+ * Using `Record<string, unknown>` provides type safety over `any`.
+ */
+export interface ErrorDetails {
+  [key: string]: unknown;
+}
+
+/**
+ * CustomError class extends the built-in Error class to include
+ * an HTTP-like status code and an optional object for more detailed errors.
+ *
+ * @param {string} message - The error message.
+ * @param {number} statusCode - An HTTP status code or application-specific error code.
+ * @param {ErrorDetails} [errors] - Optional. An object containing detailed error information.
+ */
+export class CustomError extends Error {
+  statusCode: number;
+  errors?: ErrorDetails;
+
+  constructor(message: string, statusCode: number, errors?: ErrorDetails) {
+    // Call the parent Error constructor
+    super(message);
+
+    // Assign custom properties
+    this.statusCode = statusCode;
+    this.errors = errors;
+
+    // Set the prototype explicitly. This is important for instanceof checks
+    // when extending built-in classes like Error in some environments.
+    Object.setPrototypeOf(this, CustomError.prototype);
+
+    // Set the error name to the class name
+    this.name = this.constructor.name;
+
+    // Capture the stack trace, excluding the constructor call (if available, V8 specific)
+    // Error.captureStackTrace?.(this, this.constructor);
+  }
+}
+
+// Example of how to use it (optional, for demonstration):
+/*
+try {
+  throw new CustomError("User validation failed", 400, {
+    email: "Email is already taken",
+    password: "Password must be at least 8 characters long"
+  });
+} catch (error) {
+  if (error instanceof CustomError) {
+    console.error(`Status Code: ${error.statusCode}`);
+    console.error(`Message: ${error.message}`);
+    if (error.errors) {
+      console.error(`Details: ${JSON.stringify(error.errors, null, 2)}`);
+    }
+    // console.error(error.stack);
+  } else if (error instanceof Error) {
+    console.error(`Generic Error: ${error.message}`);
+    // console.error(error.stack);
+  } else {
+    console.error("An unknown error occurred:", error);
+  }
+}
+*/

--- a/src/api/middleware/errorHandler.spec.ts
+++ b/src/api/middleware/errorHandler.spec.ts
@@ -1,10 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import errorHandler from './errorHandler';
+import { CustomError } from './customError';
 
 describe('errorHandler', () => {
   it('should handle errors correctly and return a 500 status code with an error message', () => {
-    const mockError = new Error('Test error message');
-    mockError.statusCode = 500;
+    const mockError = new CustomError('Test error message', 500);
     const mockReq = {} as Request;
     const mockRes = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
     const mockNext = jest.fn() as NextFunction;
@@ -17,8 +17,7 @@ describe('errorHandler', () => {
   });
 
   it('should handle errors with a custom status code', () => {
-    const mockError = new Error('Custom error');
-    mockError.statusCode = 400;
+    const mockError = new CustomError('Custom error', 400);
     const mockReq = {} as Request;
     const mockRes = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
     const mockNext = jest.fn() as NextFunction;
@@ -30,9 +29,7 @@ describe('errorHandler', () => {
   });
 
   it('should handle errors with errors object', () => {
-    const mockError = new Error('Validation error');
-    mockError.statusCode = 400;
-    mockError.errors = { field1: 'error message' };
+    const mockError = new CustomError('Validation error', 400, { field1: 'error message' });
     const mockReq = {} as Request;
     const mockRes = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
     const mockNext = jest.fn() as NextFunction;


### PR DESCRIPTION
Fixes ATM-1186 by creating a `CustomError` class and using it in the error handler tests.

The original tests were failing because the `Error` object does not have `statusCode` or `errors` properties. This commit introduces a `CustomError` class that extends `Error` and includes these properties. The tests are updated to use `CustomError` to ensure that the error handler is working correctly.