### PR TITLE
ATM-1195: Add comprehensive tests for webhookService.ts, including triggerWebhooks and deleteWebhook

### DIFF
--- a/src/services/webhookService.spec.ts
+++ b/src/services/webhookService.spec.ts
@@ -1,65 +1,272 @@
-import { createWebhook } from './webhookService';
+import { createWebhook, triggerWebhooks, deleteWebhook } from './webhookService';
 import { getDBConnection } from '../config/db';
+import axios from 'axios';
+import { Webhook } from '../models/webhook';
 
 // Mock the database connection module
 jest.mock('../config/db', () => ({
     getDBConnection: jest.fn()
 }));
 
+// Mock axios
+jest.mock('axios');
+
 describe('webhookService', () => {
-    // Declare the mockGetDBConnection variable with its mock type
     let mockGetDBConnection: jest.Mock;
+    let mockAxios: jest.Mocked<typeof axios>;
 
     beforeEach(() => {
-        // Assign the mocked function to the variable before each test
         mockGetDBConnection = jest.mocked(getDBConnection);
+        mockAxios = jest.mocked(axios, true);
     });
 
     afterEach(() => {
-        // Clear all mock states after each test
         jest.clearAllMocks();
     });
 
-    it('should create a new webhook', async () => {
-        const webhookData = { url: 'http://example.com/new', events: 'issue.created' };
+    describe('createWebhook', () => {
+        it('should create a new webhook', async () => {
+            const webhookData = { url: 'http://example.com/new', events: 'issue_created' };
+            const mockRunResult = { lastID: 1, changes: 1 };
+            const mockRun = jest.fn().mockResolvedValue(mockRunResult);
 
-        // Define the mock RunResult object that the promise should resolve with
-        const mockRunResult = { lastID: 1, changes: 1 };
+            mockGetDBConnection.mockResolvedValue({
+                run: mockRun,
+                all: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
 
-        // Create the mock 'run' function. It should return a Promise that resolves
-        // with an object containing the lastID and changes properties, mimicking
-        // the behavior of the promisified db.run method.
-        const mockRun = jest.fn().mockResolvedValue(mockRunResult);
+            const result = await createWebhook(webhookData);
 
-        // Configure the mock getDBConnection to return an object containing the mock 'run' function
-        mockGetDBConnection.mockResolvedValue({
-            run: mockRun,
-            // Add other methods if needed by other service functions, e.g., all, get
-            all: jest.fn(),
-            get: jest.fn(),
-            close: jest.fn(),
-            exec: jest.fn()
+            expect(mockRun).toHaveBeenCalledWith(expect.any(String), webhookData.url, webhookData.events);
+            expect(result).toEqual({ id: mockRunResult.lastID, url: webhookData.url, events: webhookData.events });
         });
 
-        // Call the function under test
-        const result = await createWebhook(webhookData);
+        it('should handle errors during webhook creation', async () => {
+            const webhookData = { url: 'http://example.com/new', events: 'issue_created' };
+            const dbError = new Error('Database error');
+            mockGetDBConnection.mockRejectedValue(dbError);
 
-        // Assert that the mock 'run' function was called with the correct SQL and parameters
-        // MODIFIED: Pass individual arguments instead of an array
-        expect(mockRun).toHaveBeenCalledWith(expect.any(String), webhookData.url, webhookData.events);
-        // Assert that the result matches the expected webhook object, using the lastID from the mock result
-        expect(result).toEqual({ id: mockRunResult.lastID, url: webhookData.url, events: webhookData.events });
+            await expect(createWebhook(webhookData)).rejects.toThrow('Database error');
+        });
     });
 
-    it('should handle errors during webhook creation', async () => {
-        const webhookData = { url: 'http://example.com/new', events: 'issue.created' };
-        // Configure the mock getDBConnection to reject with an error
-        const dbError = new Error('Database error');
-        mockGetDBConnection.mockRejectedValue(dbError);
+    describe('deleteWebhook', () => {
+        it('should successfully delete a webhook', async () => {
+            const webhookId = '123';
+            const mockRunResult = { changes: 1 };
+            const mockRun = jest.fn().mockResolvedValue(mockRunResult);
 
-        // Assert that calling createWebhook rejects with the expected error
-        await expect(createWebhook(webhookData)).rejects.toThrow('Database error');
+            mockGetDBConnection.mockResolvedValue({
+                run: mockRun,
+                all: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
+
+            await deleteWebhook(webhookId);
+
+            expect(mockRun).toHaveBeenCalledWith(expect.any(String), webhookId);
+        });
+
+        it('should handle the case when a webhook with the specified ID does not exist', async () => {
+            const webhookId = '456';
+            const mockRunResult = { changes: 0 }; // No rows affected
+            const mockRun = jest.fn().mockResolvedValue(mockRunResult);
+
+            mockGetDBConnection.mockResolvedValue({
+                run: mockRun,
+                all: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
+
+            await deleteWebhook(webhookId);
+
+            expect(mockRun).toHaveBeenCalledWith(expect.any(String), webhookId);
+            // Add an assertion to check if the lack of deletion is handled correctly (e.g., no error thrown)
+            // Or if you want to throw an error when no rows are deleted, you can adjust the function and test for that.
+        });
+
+        it('should handle errors during webhook deletion', async () => {
+            const webhookId = '789';
+            const dbError = new Error('Database error');
+            mockGetDBConnection.mockRejectedValue(dbError);
+
+            await expect(deleteWebhook(webhookId)).rejects.toThrow('Database error');
+        });
     });
 
-    // Add more tests for other functions like deleteWebhook and triggerWebhooks if needed
+    describe('triggerWebhooks', () => {
+        const mockIssueData = { id: 1, title: 'Test Issue' };
+
+        it('should trigger the correct webhooks based on the event type', async () => {
+            const eventType = 'issue_created';
+            const mockWebhooks: Webhook[] = [
+                { id: 1, url: 'http://example.com/webhook1', events: ['issue_created'], secret: '' },
+                { id: 2, url: 'http://example.com/webhook2', events: ['issue_updated'], secret: '' },
+                { id: 3, url: 'http://example.com/webhook3', events: ['issue_created', 'issue_updated'], secret: '' },
+                { id: 4, url: 'http://example.com/webhook4', events: ['issue_deleted'], secret: '' }
+            ];
+
+            mockGetDBConnection.mockResolvedValue({
+                all: jest.fn().mockResolvedValue(mockWebhooks),
+                run: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
+
+            mockAxios.post.mockResolvedValue({ status: 200 });
+
+            await triggerWebhooks(eventType, mockIssueData);
+
+            expect(mockGetDBConnection).toHaveBeenCalledTimes(1);
+            expect(mockAxios.post).toHaveBeenCalledTimes(2); // Only webhook1 and webhook3 should be called
+            expect(mockAxios.post).toHaveBeenCalledWith('http://example.com/webhook1', expect.any(Object), expect.any(Object));
+            expect(mockAxios.post).toHaveBeenCalledWith('http://example.com/webhook3', expect.any(Object), expect.any(Object));
+        });
+
+        it('should send the correct payload to each webhook', async () => {
+            const eventType = 'issue_created';
+            const mockWebhook: Webhook[] = [{ id: 1, url: 'http://example.com/webhook1', events: ['issue_created'], secret: '' }];
+
+            mockGetDBConnection.mockResolvedValue({
+                all: jest.fn().mockResolvedValue(mockWebhook),
+                run: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
+
+            mockAxios.post.mockResolvedValue({ status: 200 });
+
+            await triggerWebhooks(eventType, mockIssueData);
+
+            expect(mockAxios.post).toHaveBeenCalledWith(
+                'http://example.com/webhook1',
+                expect.objectContaining({
+                    webhookEvent: eventType,
+                    issue: mockIssueData,
+                }),
+                expect.any(Object)
+            );
+        });
+
+        it('should handle successful webhook call', async () => {
+            const eventType = 'issue_created';
+            const mockWebhook: Webhook[] = [{ id: 1, url: 'http://example.com/webhook1', events: ['issue_created'], secret: '' }];
+
+            mockGetDBConnection.mockResolvedValue({
+                all: jest.fn().mockResolvedValue(mockWebhook),
+                run: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
+
+            mockAxios.post.mockResolvedValue({ status: 200 });
+
+            await triggerWebhooks(eventType, mockIssueData);
+
+            expect(mockAxios.post).toHaveBeenCalledTimes(1);
+
+        });
+
+        it('should handle failed webhook calls and retry logic', async () => {
+            const eventType = 'issue_created';
+            const mockWebhook: Webhook[] = [{ id: 1, url: 'http://example.com/webhook1', events: ['issue_created'], secret: '' }];
+
+            mockGetDBConnection.mockResolvedValue({
+                all: jest.fn().mockResolvedValue(mockWebhook),
+                run: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
+
+            mockAxios.post.mockRejectedValue(new Error('Network error'));
+
+            await triggerWebhooks(eventType, mockIssueData);
+
+            expect(mockAxios.post).toHaveBeenCalledTimes(4); // 1 initial call + 3 retries
+        });
+
+        it('should handle server errors (500 status code) during webhook calls and retry logic', async () => {
+            const eventType = 'issue_created';
+            const mockWebhook: Webhook[] = [{ id: 1, url: 'http://example.com/webhook1', events: ['issue_created'], secret: '' }];
+
+            mockGetDBConnection.mockResolvedValue({
+                all: jest.fn().mockResolvedValue(mockWebhook),
+                run: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
+
+            mockAxios.post.mockRejectedValue({
+                response: {
+                    status: 500,
+                    data: 'Internal Server Error'
+                }
+            });
+
+            await triggerWebhooks(eventType, mockIssueData);
+
+            expect(mockAxios.post).toHaveBeenCalledTimes(4); // 1 initial call + 3 retries
+        });
+
+        it('should handle no webhooks registered for the event type', async () => {
+            const eventType = 'issue_created';
+
+            mockGetDBConnection.mockResolvedValue({
+                all: jest.fn().mockResolvedValue([]), // No webhooks returned
+                run: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
+
+            await triggerWebhooks(eventType, mockIssueData);
+
+            expect(mockAxios.post).not.toHaveBeenCalled(); // Ensure no webhooks are called
+        });
+
+        it('should handle errors during fetching webhooks from the database', async () => {
+            const eventType = 'issue_created';
+            const dbError = new Error('Database error');
+
+            mockGetDBConnection.mockRejectedValue(dbError);
+
+            await triggerWebhooks(eventType, mockIssueData);
+
+            // Expect no axios calls to have happened.
+            expect(mockAxios.post).not.toHaveBeenCalled();
+        });
+
+         it('should not trigger webhooks if event is a substring of the registered event', async () => {
+            const eventType = 'issue';
+            const mockWebhooks: Webhook[] = [
+                { id: 1, url: 'http://example.com/webhook1', events: ['issue_created'], secret: '' },
+            ];
+
+            mockGetDBConnection.mockResolvedValue({
+                all: jest.fn().mockResolvedValue(mockWebhooks),
+                run: jest.fn(),
+                get: jest.fn(),
+                close: jest.fn(),
+                exec: jest.fn()
+            });
+
+            mockAxios.post.mockResolvedValue({ status: 200 });
+
+            await triggerWebhooks(eventType, mockIssueData);
+
+            expect(mockAxios.post).not.toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
This pull request adds comprehensive tests for `webhookService.ts`, covering the `triggerWebhooks` and `deleteWebhook` functions, including edge cases and retry logic.