### PR TITLE
ATM-1205: Compilation error in issueRoutes.spec.ts

### DIFF
--- a/src/api/controllers/issueController.createIssue.spec.ts
+++ b/src/api/controllers/issueController.createIssue.spec.ts
@@ -1,5 +1,4 @@
 // src/api/controllers/issueController.createIssue.spec.ts
-
 import { IssueController } from './issueController';
 import { DatabaseService } from '../../services/databaseService';
 import { IssueKeyService } from '../../services/issueKeyService';
@@ -9,15 +8,13 @@ import { Issue } from '../../models/issue';
 import { ObjectId } from 'mongodb'; // Used for _id generation in tests
 import httpMocks from 'node-mocks-http';
 import { triggerWebhooks } from '../../services/webhookService';
-import { formatIssueResponse } from '../../utils/jsonTransformer';
+import { formatIssueResponse } from '../../utils/jsonTransformer'; // Assuming this is where the function is
 import { createMockDbConnection } from '../../mocks/sqlite3.mock';
 
 // Mock external dependencies
 jest.mock('../../services/webhookService', () => ({}));
-
 jest.mock('../../services/issueKeyService');
 jest.mock('../../services/issueStatusTransitionService');
-
 // Mock the DatabaseService *and* its potential underlying connection source
 const mockDbConnection = createMockDbConnection();
 jest.mock('../../config/db', () => ({
@@ -41,25 +38,21 @@ const mockDatabaseServiceInstance = {
 jest.mock('../../services/databaseService', () => {
     return {DatabaseService: jest.fn().mockImplementation(() => mockDatabaseServiceInstance)};
 });
-
 const mockTriggerWebhooks = triggerWebhooks as jest.Mock;
-
 type DbIssue = Issue & { id: number; key: string; status: string; assignee_key?: string | null; created_at: string; updated_at: string; };
-
 describe('IssueController - createIssue', () => {
     let controller: IssueController;
     let mockRequest: httpMocks.MockRequest<Request>;
     let mockResponse: httpMocks.MockResponse<Response>;
     const mockNext: jest.Mock = jest.fn();
-
     beforeEach(() => {
         jest.clearAllMocks();
         Object.values(mockDatabaseServiceInstance).forEach(mockFn => mockFn.mockClear());
         controller = new IssueController(
             new DatabaseService(),
-            new IssueKeyService(),
-            new IssueStatusTransitionService()
-        );
+            new IssueKeyService(mockDatabaseServiceInstance),
+            new IssueStatusTransitionService(mockDatabaseServiceInstance)
+            );
         mockRequest = httpMocks.createRequest();
         mockResponse = httpMocks.createResponse();
     });

--- a/src/api/routes/issueRoutes.spec.ts
+++ b/src/api/routes/issueRoutes.spec.ts
@@ -1,26 +1,21 @@
 import supertest from 'supertest';
 import express, { Request, Response, NextFunction } from 'express';
 import { createMock } from '@golevelup/ts-jest';
-
 // Import services to be mocked
 import { DatabaseService } from '../../services/databaseService';
 import { IssueKeyService } from '../../services/issueKeyService';
 import { IssueStatusTransitionService } from '../../services/issueStatusTransitionService';
 import { triggerWebhooks } from '../../services/webhookService';
-
 // Import utility and model
 import { formatIssueResponse } from '../../utils/jsonTransformer';
 import { Issue } from '../../models/issue';
-
 // --- Mock Dependencies BEFORE Importing Controller/Routes ---
-
 // Create mock instances using @golevelup/ts-jest for convenience
 const mockDatabaseService = createMock<DatabaseService>();
 const mockIssueKeyService = createMock<IssueKeyService>();
 const mockIssueStatusTransitionService = createMock<IssueStatusTransitionService>();
 // Create a standard Jest mock for the standalone function
 const mockTriggerWebhooks = jest.fn();
-
 // Mock the modules themselves. This intercepts imports within the controller.
 // When the actual IssueController is instantiated (likely triggered by importing issueRoutes),
 // it will receive these mocked instances instead of the real ones.
@@ -40,35 +35,29 @@ jest.mock('../../services/webhookService', () => ({
     // Mock the specific exported function
     triggerWebhooks: mockTriggerWebhooks
 }));
-
 // --- Import Controller and Routes AFTER Mocks are Set Up ---
 // Import the *actual* controller. Its dependencies will be mocked due to the above setup.
 // Note: The instantiation logic in `issueController.ts` (if it exports an instance)
 // will use the mocked services.
 import { IssueController } from '../controllers/issueController'; // Import the actual controller class
 import issueRoutes from './issueRoutes'; // Import the actual routes
-
 // --- Test Setup ---
-
 // Define a type for the expected shape of DB issues
 // Ensure nullable fields match the database schema and usage
 type DbIssue = Issue & {
     id: number;
+    _id: string;
     key: string;
     status: string;
     assignee_key: string | null | undefined;
     created_at: string;
     updated_at: string;
-    _id: string;
     parentKey: string | null | undefined;
 };
-
 // Create Express app for testing
 const app = express();
-
 // Middleware Setup
 app.use(express.json());
-
 // !! Crucial for testing dependency injection via req.app.locals if used !!
 // If the controller *did* access services via req.app.locals, this would inject mocks.
 // However, based on the provided controller code using constructor injection,
@@ -82,12 +71,9 @@ app.use((req: Request, res: Response, next: NextFunction) => {
     // We DO NOT add the controller itself to locals as we want the routes to use the actual controller
     next();
 });
-
-
 // Mount the *actual* routes. These routes use the actual IssueController instance,
 // which has been instantiated with mocked services because jest.mock intercepted the service imports.
 app.use('/rest/api/3/issue', issueRoutes);
-
 // Add a generic error handler *after* routes to catch errors passed via next()
 // This is useful for testing 500 error scenarios originating from the controller
 app.use((err: Error & { statusCode?: number }, req: Request, res: Response, next: NextFunction) => {
@@ -99,30 +85,22 @@ app.use((err: Error & { statusCode?: number }, req: Request, res: Response, next
         next(err); // Delegate to default Express handler if headers sent
     }
 });
-
-
 // --- Test Suite ---
-
 describe('issueRoutes Integration Tests', () => {
     let request: supertest.SuperTest<supertest.Test>;
-
     beforeAll(() => {
         // Instantiate supertest with the test app
         request = supertest(app);
     });
-
     beforeEach(() => {
         // Reset mocks before each test to ensure isolation
         jest.clearAllMocks();
-
         // You might need to reset specific mock implementations if they are stateful
         // e.g., mockDatabaseService.get.mockReset();
         //       mockIssueKeyService.getNextIssueKey.mockReset(); etc.
         // Using jest.clearAllMocks() is generally sufficient for clearing calls and instances.
     });
-
     // --- Test Cases ---
-
     describe('POST /rest/api/3/issue', () => {
         it('should call IssueController.createIssue and return 201 on success', async () => {
             // Arrange: Configure Mocks for the Controller's logic
@@ -135,7 +113,8 @@ describe('issueRoutes Integration Tests', () => {
             const now = new Date().toISOString();
             // Simulate the shape of the data the controller expects to retrieve after insertion
             // Use Omit carefully, ensure remaining properties match the target type
-            const createdDbIssueBase: Omit<DbIssue, '_id' | 'assignee_key' | 'parentKey'> = {
+            const createdDbIssueBase: Omit<DbIssue, 'assignee_key' | 'parentKey'> = {
+                _id: '653412345678901234567890',
                 id: 1,
                 issuetype: issueData.issuetype,
                 summary: issueData.summary,
@@ -145,28 +124,24 @@ describe('issueRoutes Integration Tests', () => {
                 created_at: now,
                 updated_at: now,
             };
-            const createdDbIssueWithNulls: Omit<DbIssue, '_id'> = {
+            const createdDbIssueWithNulls: DbIssue = {
                 ...createdDbIssueBase,
                 assignee_key: null,
                 parentKey: null
             }
-
             // The controller will format this before sending
-            const dbIssueForFormatting: DbIssue = { ...createdDbIssueWithNulls, _id: 'mock_db_id_1' };
+            const dbIssueForFormatting: DbIssue = { ...createdDbIssueWithNulls };
             const formattedResponse = formatIssueResponse(dbIssueForFormatting); // Add dummy _id for format function
-
             mockIssueKeyService.getNextIssueKey.mockResolvedValue(issueKey);
             mockDatabaseService.run.mockResolvedValue(undefined); // Mock the INSERT operation
             mockDatabaseService.get.mockResolvedValue(dbIssueForFormatting); // Mock the SELECT after insert
             mockTriggerWebhooks.mockResolvedValue(undefined); // Mock webhook trigger
-
             // Act: Make the request
             const response = await request
                 .post('/rest/api/3/issue')
                 .send(issueData)
                 .set('Accept', 'application/json')
                 .set('Content-Type', 'application/json');
-
             // Assert: Verify Response and Mock Interactions
             expect(response.status).toBe(201);
             expect(response.body).toEqual(formattedResponse); // Check the formatted response
@@ -190,18 +165,15 @@ describe('issueRoutes Integration Tests', () => {
             );
             expect(mockTriggerWebhooks).toHaveBeenCalledWith('jira:issue_created', formattedResponse);
         });
-
         it('should return 400 if required fields are missing (handled by controller)', async () => {
             // Arrange: Send invalid data
             const invalidIssueData = { description: 'Only description' };
-
             // Act
             const response = await request
                 .post('/rest/api/3/issue')
                 .send(invalidIssueData)
                 .set('Accept', 'application/json')
                 .set('Content-Type', 'application/json');
-
             // Assert
             expect(response.status).toBe(400);
             expect(response.body).toEqual({ message: 'Missing required fields' });
@@ -210,24 +182,20 @@ describe('issueRoutes Integration Tests', () => {
             expect(mockDatabaseService.run).not.toHaveBeenCalled();
             expect(mockTriggerWebhooks).not.toHaveBeenCalled();
         });
-
         it('should return 500 if the controller encounters a database error during creation', async () => {
             // Arrange: Simulate a database error
             const issueData = { issuetype: 'bug', summary: 'DB Error Test', description: '...' };
             const issueKey = 'TASK-2';
             const dbError = new Error('Database connection lost');
-
             mockIssueKeyService.getNextIssueKey.mockResolvedValue(issueKey);
             // Simulate failure on the INSERT step
             mockDatabaseService.run.mockRejectedValue(dbError);
-
             // Act
             const response = await request
                 .post('/rest/api/3/issue')
                 .send(issueData)
                 .set('Accept', 'application/json')
                 .set('Content-Type', 'application/json');
-
             // Assert
             expect(response.status).toBe(500);
             // The controller's catch block should produce this message
@@ -238,21 +206,18 @@ describe('issueRoutes Integration Tests', () => {
             expect(mockTriggerWebhooks).not.toHaveBeenCalled();
         });
     });
-
     describe('GET /rest/api/3/issue/:issueIdOrKey', () => {
         it('should call IssueController.getIssue and return 200 with issue data if found by key', async () => {
             // Arrange
             const issueKey = 'PROJ-123';
             const now = new Date().toISOString();
-            const dbIssue: DbIssue = { _id: 'mock_db_id_123', id: 123, issuetype: 'story', summary: 'Get By Key', description: 'Test description', key: issueKey, status: 'In Progress', assignee_key: 'user-1', created_at: now, updated_at: now, parentKey: null };
+            const dbIssue: DbIssue = { _id: '653412345678901234567890', id: 123, issuetype: 'story', summary: 'Get By Key', description: 'Test description', key: issueKey, status: 'In Progress', assignee_key: 'user-1', created_at: now, updated_at: now, parentKey: null };
             const formattedResponse = formatIssueResponse(dbIssue);
 
             // Mock the service call made by the controller
             mockDatabaseService.get.mockResolvedValue(dbIssue);
-
             // Act
             const response = await request.get(`/rest/api/3/issue/${issueKey}`);
-
             // Assert
             expect(response.status).toBe(200);
             expect(response.body).toEqual(formattedResponse);
@@ -262,19 +227,16 @@ describe('issueRoutes Integration Tests', () => {
                 [issueKey]
             );
         });
-
         it('should call IssueController.getIssue and return 200 with issue data if found by ID', async () => {
             // Arrange
             const issueId = '456'; // ID as string, matching param type
             const now = new Date().toISOString();
-            const dbIssue: DbIssue = { _id: 'mock_db_id_456', id: 456, issuetype: 'bug', summary: 'Get By ID', description: 'Bug description', key: 'BUG-1', status: 'To Do', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
+            const dbIssue: DbIssue = { _id: '653412345678901234567890', id: 456, issuetype: 'bug', summary: 'Get By ID', description: 'Bug description', key: 'BUG-1', status: 'To Do', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
             const formattedResponse = formatIssueResponse(dbIssue);
 
             mockDatabaseService.get.mockResolvedValue(dbIssue);
-
             // Act
             const response = await request.get(`/rest/api/3/issue/${issueId}`);
-
             // Assert
             expect(response.status).toBe(200);
             expect(response.body).toEqual(formattedResponse);
@@ -284,15 +246,12 @@ describe('issueRoutes Integration Tests', () => {
                 [issueId]
             );
         });
-
         it('should return 404 if the issue is not found', async () => {
             // Arrange
             const issueKey = 'NONEXISTENT-KEY';
             mockDatabaseService.get.mockResolvedValue(undefined); // Simulate not found
-
             // Act
             const response = await request.get(`/rest/api/3/issue/${issueKey}`);
-
             // Assert
             expect(response.status).toBe(404);
             expect(response.body).toEqual({ message: 'Issue not found' });
@@ -302,23 +261,19 @@ describe('issueRoutes Integration Tests', () => {
                 [issueKey]
             );
         });
-
         it('should return 500 if the controller encounters a database error during retrieval', async () => {
             // Arrange
             const issueKey = 'DB-ERROR-KEY';
             const dbError = new Error('Failed to query');
             mockDatabaseService.get.mockRejectedValue(dbError);
-
             // Act
             const response = await request.get(`/rest/api/3/issue/${issueKey}`);
-
             // Assert
             expect(response.status).toBe(500);
             expect(response.body).toEqual({ message: 'Failed to retrieve issue' }); // Controller's error message
             expect(mockDatabaseService.get).toHaveBeenCalledTimes(1);
         });
     });
-
     describe('PUT /rest/api/3/issue/:issueIdOrKey', () => {
         it('should call IssueController.updateIssue and return 204 on successful update', async () => {
             // Arrange
@@ -326,7 +281,7 @@ describe('issueRoutes Integration Tests', () => {
             const updateData = { summary: 'Updated Summary', description: 'New description' };
             const now = new Date().toISOString();
             // Simulate issue state *before* update for controller's pre-fetch
-            const preUpdateDbIssue: DbIssue = { _id: 'mock_db_id_upd', id: 789, issuetype: 'task', summary: 'Old Summary', description: 'Old desc', key: issueKey, status: 'To Do', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
+            const preUpdateDbIssue: DbIssue = { _id: '653412345678901234567890', id: 789, issuetype: 'task', summary: 'Old Summary', description: 'Old desc', key: issueKey, status: 'To Do', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
             // Simulate issue state *after* update for controller's post-fetch (for webhook)
             const postUpdateDbIssue: DbIssue = { ...preUpdateDbIssue, summary: updateData.summary, description: updateData.description, updated_at: new Date().toISOString() };
             const formattedWebhookPayload = formatIssueResponse(postUpdateDbIssue);
@@ -338,12 +293,10 @@ describe('issueRoutes Integration Tests', () => {
             mockTriggerWebhooks.mockResolvedValue(undefined);
             // Status transition mock (assuming status is not changed, so it passes trivially or isn't called)
             mockIssueStatusTransitionService.isValidTransition.mockResolvedValue(true); // Assume valid if called
-
             // Act
             const response = await request
                 .put(`/rest/api/3/issue/${issueKey}`)
                 .send(updateData);
-
             // Assert
             expect(response.status).toBe(204); // No content on successful PUT
             expect(mockDatabaseService.get).toHaveBeenCalledTimes(2); // Pre-fetch and post-fetch
@@ -363,18 +316,15 @@ describe('issueRoutes Integration Tests', () => {
             // Ensure transition check wasn't needed/called if status wasn't in updateData
             expect(mockIssueStatusTransitionService.isValidTransition).not.toHaveBeenCalled();
         });
-
         it('should return 404 if the issue to update is not found', async () => {
             // Arrange
             const issueKey = 'NONEXISTENT-PUT';
             const updateData = { summary: 'Wont happen' };
             mockDatabaseService.get.mockResolvedValue(undefined); // Simulate not found on pre-fetch
-
             // Act
             const response = await request
                 .put(`/rest/api/3/issue/${issueKey}`)
                 .send(updateData);
-
             // Assert
             expect(response.status).toBe(404);
             expect(response.body).toEqual({ message: 'Issue not found' });
@@ -382,7 +332,6 @@ describe('issueRoutes Integration Tests', () => {
             expect(mockDatabaseService.run).not.toHaveBeenCalled();
             expect(mockTriggerWebhooks).not.toHaveBeenCalled();
         });
-
         it('should return 400 if an invalid status transition is attempted', async () => {
             // Arrange
             const issueKey = 'INVALID-TRANSITION';
@@ -393,20 +342,18 @@ describe('issueRoutes Integration Tests', () => {
             const currentStatusId = 11; // Hypothetical ID for 'To Do'
             const targetStatusId = 31;  // Hypothetical ID for 'Done'
 
-            // Simulate the current state of the issue
-            const preUpdateDbIssue: DbIssue = { _id: 'mock_db_id_trans', id: 890, issuetype: 'task', summary: 'Transition Test', description: '', key: issueKey, status: currentStatus, assignee_key: null, created_at: now, updated_at: now, parentKey: null };
+             // Simulate the current state of the issue
+            const preUpdateDbIssue: DbIssue = { _id: '653412345678901234567890', id: 890, issuetype: 'task', summary: 'Transition Test', description: '', key: issueKey, status: currentStatus, assignee_key: null, created_at: now, updated_at: now, parentKey: null };
 
             mockDatabaseService.get.mockResolvedValue(preUpdateDbIssue); // Mock pre-fetch
             // Mock the transition service to return false for this specific transition attempt
             mockIssueStatusTransitionService.isValidTransition.mockResolvedValue(false);
             // We assume the controller will fetch status IDs based on names 'To Do' and 'Done'
             // and pass these IDs to the service. Our mock setup intercepts the service call.
-
             // Act
             const response = await request
                 .put(`/rest/api/3/issue/${issueKey}`)
                 .send(updateData);
-
             // Assert
             expect(response.status).toBe(400);
             expect(response.body).toEqual({ message: `Invalid status transition from '${currentStatus}' to '${updateData.status}'` });
@@ -423,24 +370,20 @@ describe('issueRoutes Integration Tests', () => {
             expect(mockDatabaseService.run).not.toHaveBeenCalled(); // Update shouldn't happen
             expect(mockTriggerWebhooks).not.toHaveBeenCalled();
         });
-
-
         it('should return 500 if the controller encounters a database error during update', async () => {
             // Arrange
             const issueKey = 'DB-ERROR-PUT';
             const updateData = { summary: 'Error Update' };
             const now = new Date().toISOString();
-            const preUpdateDbIssue: DbIssue = { _id: 'mock_db_id_err_put', id: 901, issuetype: 'task', summary: 'Old', description: '', key: issueKey, status: 'To Do', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
+            const preUpdateDbIssue: DbIssue = { _id: '653412345678901234567890', id: 901, issuetype: 'task', summary: 'Old', description: '', key: issueKey, status: 'To Do', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
             const dbError = new Error('Update failed');
 
             mockDatabaseService.get.mockResolvedValue(preUpdateDbIssue); // Pre-fetch succeeds
             mockDatabaseService.run.mockRejectedValue(dbError); // Simulate failure on UPDATE
-
             // Act
             const response = await request
                 .put(`/rest/api/3/issue/${issueKey}`)
                 .send(updateData);
-
             // Assert
             expect(response.status).toBe(500);
             expect(response.body).toEqual({ message: 'Failed to update issue' }); // Controller's error message
@@ -449,23 +392,20 @@ describe('issueRoutes Integration Tests', () => {
             expect(mockTriggerWebhooks).not.toHaveBeenCalled(); // Should not be called after failure
         });
     });
-
     describe('DELETE /rest/api/3/issue/:issueIdOrKey', () => {
         it('should call IssueController.deleteIssue and return 204 on successful deletion', async () => {
             // Arrange
             const issueKey = 'PROJ-DELETE';
             const now = new Date().toISOString();
             // Simulate issue state *before* deletion for controller's pre-fetch (for webhook)
-            const preDeleteDbIssue: DbIssue = { _id: 'mock_db_id_del', id: 1001, issuetype: 'bug', summary: 'To Be Deleted', description: '', key: issueKey, status: 'Done', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
+            const preDeleteDbIssue: DbIssue = { _id: '653412345678901234567890', id: 1001, issuetype: 'bug', summary: 'To Be Deleted', description: '', key: issueKey, status: 'Done', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
             const formattedWebhookPayload = formatIssueResponse(preDeleteDbIssue);
 
             mockDatabaseService.get.mockResolvedValue(preDeleteDbIssue); // Mock pre-fetch for webhook
             mockDatabaseService.run.mockResolvedValue(undefined); // Mock the DELETE operation
             mockTriggerWebhooks.mockResolvedValue(undefined);
-
             // Act
             const response = await request.delete(`/rest/api/3/issue/${issueKey}`);
-
             // Assert
             expect(response.status).toBe(204); // No content on successful DELETE
             expect(mockDatabaseService.get).toHaveBeenCalledTimes(1); // Pre-fetch for webhook
@@ -477,15 +417,12 @@ describe('issueRoutes Integration Tests', () => {
             );
             expect(mockTriggerWebhooks).toHaveBeenCalledWith('jira:issue_deleted', formattedWebhookPayload);
         });
-
         it('should return 404 if the issue to delete is not found', async () => {
             // Arrange
             const issueKey = 'NONEXISTENT-DEL';
             mockDatabaseService.get.mockResolvedValue(undefined); // Simulate not found on pre-fetch
-
             // Act
             const response = await request.delete(`/rest/api/3/issue/${issueKey}`);
-
             // Assert
             expect(response.status).toBe(404);
             expect(response.body).toEqual({ message: 'Issue not found' });
@@ -493,12 +430,11 @@ describe('issueRoutes Integration Tests', () => {
             expect(mockDatabaseService.run).not.toHaveBeenCalled();
             expect(mockTriggerWebhooks).not.toHaveBeenCalled();
         });
-
         it('should return 500 if the controller encounters a database error during deletion', async () => {
              // Arrange
             const issueKey = 'DB-ERROR-DEL';
             const now = new Date().toISOString();
-            const preDeleteDbIssue: DbIssue = { _id: 'mock_db_id_err_del', id: 1002, issuetype: 'bug', summary: 'Delete Error', description: '', key: issueKey, status: 'Done', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
+            const preDeleteDbIssue: DbIssue = { _id: '653412345678901234567890', id: 1002, issuetype: 'bug', summary: 'Delete Error', description: '', key: issueKey, status: 'Done', assignee_key: null, created_at: now, updated_at: now, parentKey: null };
             const dbError = new Error('Delete failed');
 
             mockDatabaseService.get.mockResolvedValue(preDeleteDbIssue); // Pre-fetch succeeds

--- a/src/models/issue.ts
+++ b/src/models/issue.ts
@@ -1,17 +1,9 @@
 import { z } from 'zod';
-
 /**
  * Represents a generic issue, often corresponding to an item in an issue tracking system.
  * Contains core details necessary to identify and describe an issue.
  */
 export interface Issue {
-  /**
-   * Unique identifier for the issue, often assigned by the underlying data store (e.g., MongoDB ObjectId).
-   * Must be a non-empty string.
-   * @example '60c72b2f9b1e8a5a4d8b4567'
-   */
-  _id: string;
-
   /**
    * The type of the issue (e.g., Bug, Task, Story, Epic).
    * Helps categorize the issue. Must be a non-empty string.
@@ -19,21 +11,18 @@ export interface Issue {
    * @example 'Story'
    */
   issuetype: string;
-
   /**
    * A brief summary or title of the issue.
    * Must be a non-empty string.
    * @example 'Login button unresponsive on Safari'
    */
   summary: string;
-
   /**
    * A detailed description of the issue, including steps to reproduce, context, etc.
    * Must be a non-empty string.
    * @example 'When a user clicks the login button on Safari version 15.1, nothing happens. Expected behavior is redirection to the dashboard.'
    */
   description: string;
-
   /**
    * Optional key of the parent issue, if this issue is a sub-task or part of a larger item (like an Epic).
    * Can be a string, null, or undefined.
@@ -41,13 +30,19 @@ export interface Issue {
    * @example null // No parent
    */
   parentKey?: string | null;
-
   /**
    * A human-readable unique identifier for the issue, often used in project management tools (e.g., JIRA key).
    * Must be a non-empty string.
    * @example 'PROJECT-456'
    */
   key: string;
+  /**
+   * Unique identifier for the issue, often assigned by the underlying data store (e.g., MongoDB ObjectId).
+   * Must be a non-empty string.
+   * @example '60c72b2f9b1e8a5a4d8b4567'
+   */
+  _id: string;
+
 }
 
 /**


### PR DESCRIPTION
Added the `_id` field to the `Issue` interface and updated the `issueRoutes.spec.ts` file to include the `_id` field in the `DbIssue` type definitions and all issue objects used in the tests.