### PR TITLE
ATM-1292: Issue Key Generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "uuid": "^11.1.0"
       },
       "devDependencies": {
-        "@types/chai": "^4.0.0",
-        "@types/mocha": "^10.0.0",
+        "@types/chai": "^4.3.20",
+        "@types/mocha": "^10.0.10",
         "@types/node": "^22.15.19",
-        "chai": "^4.0.0",
+        "chai": "^4.5.0",
         "mocha": "^11.4.0",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/mocha": "^10.0.0",
+    "@types/chai": "^4.3.20",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^22.15.19",
+    "chai": "^4.5.0",
     "mocha": "^11.4.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.8.3",
-    "chai": "^4.0.0",
-    "@types/chai": "^4.0.0"
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "@types/express": "^5.0.2",

--- a/src/utils/issueKeyGenerator.test.ts
+++ b/src/utils/issueKeyGenerator.test.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { generateIssueKey } from './issueKeyGenerator';
+
+describe('generateIssueKey', () => {
+  it('should generate a TASK key', () => {
+    expect(generateIssueKey('Task', 1)).to.equal('TASK-1');
+  });
+
+  it('should generate an EPIC key', () => {
+    expect(generateIssueKey('Epic', 2)).to.equal('EPIC-2');
+  });
+
+  it('should generate a STOR key', () => {
+    expect(generateIssueKey('Story', 3)).to.equal('STOR-3');
+  });
+
+  it('should generate a BUG key', () => {
+    expect(generateIssueKey('Bug', 4)).to.equal('BUG-4');
+  });
+
+  it('should generate a SUBT key', () => {
+    expect(generateIssueKey('Subtask', 5)).to.equal('SUBT-5');
+  });
+
+  it('should throw an error for an unknown issue type', () => {
+    expect(() => generateIssueKey('Unknown', 6)).to.throw('Unknown issue type: Unknown');
+  });
+});

--- a/src/utils/issueKeyGenerator.ts
+++ b/src/utils/issueKeyGenerator.ts
@@ -1,0 +1,22 @@
+/**
+ * Generates a unique issue key.
+ * @param issueType The type of the issue (e.g., "Task", "Epic").
+ * @param counter The current global counter.
+ * @returns The generated issue key.
+ * @throws Error if the issue type is unknown.
+ */
+export function generateIssueKey(issueType: string, counter: number): string {
+  const typePrefix = {
+    Task: "TASK",
+    Story: "STOR",
+    Epic: "EPIC",
+    Bug: "BUG",
+    Subtask: "SUBT",
+  }[issueType];
+
+  if (!typePrefix) {
+    throw new Error(`Unknown issue type: ${issueType}`);
+  }
+
+  return `${typePrefix}-${counter}`;
+}


### PR DESCRIPTION
Implement utility function for generating unique issue keys (ATM-1292).

This includes the `generateIssueKey` function which takes an issue type and a counter to produce keys like "TASK-1". It supports standard issue types (Task, Story, Epic, Bug, Subtask) and throws an error for unknown types.

Unit tests for the function are included and passing.