### PR TITLE
ATM-1295: Implement API Route and Controller Setup

### DIFF
--- a/src/api/controllers/issueController.ts
+++ b/src/api/controllers/issueController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express';
+import { createIssue as createIssueService } from '../../services/issueService';
 
 /**
  * Handles the creation of a new issue.
@@ -6,9 +7,7 @@ import { Request, Response } from 'express';
  * @param req - The Express request object.
  * @param res - The Express response object.
  */
-export const createIssue = (req: Request, res: Response): void => {
-  console.log('createIssue function called');
-
+export const createIssue = async (req: Request, res: Response): Promise<void> => {
   const { fields } = req.body;
 
   if (!fields?.project?.key) {
@@ -23,6 +22,20 @@ export const createIssue = (req: Request, res: Response): void => {
     return res.status(400).json({ error: 'Summary is required' });
   }
 
-  console.log('Request body:', req.body);
-  res.status(201).json({ message: 'Issue creation request received' });
+  try {
+    const createdIssue = await createIssueService({
+      projectKey: fields.project.key,
+      issueTypeId: fields.issuetype.id,
+      summary: fields.summary,
+      description: fields.description,
+    });
+    res.status(201).json({
+      id: createdIssue.id,
+      key: createdIssue.key,
+      self: createdIssue.self,
+    });
+  } catch (error) {
+    console.error('Error creating issue:', error);
+    res.status(500).json({ error: 'Failed to create issue' });
+  }
 };

--- a/src/services/issueService.ts
+++ b/src/services/issueService.ts
@@ -1,0 +1,56 @@
+import { Issue } from '../models/issue';
+import { v4 as uuidv4 } from 'uuid';
+import { loadDatabase, saveDatabase } from '../db/persistence'; // Import persistence functions
+import { generateIssueKey } from '../utils/issueKeyGenerator'; // Import key generator
+import { AnyIssue } from '../models/anyIssue'; // Import AnyIssue for type compatibility with DbSchema
+
+export interface IssueCreationData {
+    projectKey: string;
+    issueTypeId: string;
+    summary: string;
+    description?: string;
+}
+
+/**
+ * Creates a new issue and persists it to the database.
+ * @param data - The data required to create the issue.
+ * @returns A promise that resolves with the newly created issue object.
+ */
+export const createIssue = async (data: IssueCreationData): Promise<Issue> => {
+  // 1. Load the current database state
+  const db = await loadDatabase();
+
+  // 2. Generate a unique issue key and increment the counter
+  const newCounter = db.issueKeyCounter + 1;
+  const issueKey = generateIssueKey(data.issueTypeId, newCounter);
+
+  // 3. Create the new issue object
+  // A common base structure is sufficient for this task based on models and task description.
+  const newIssue: AnyIssue = { // Cast to AnyIssue to match the DbSchema storage type
+      id: uuidv4(), // Generate a unique ID
+      key: issueKey,
+      // Use a relative path for the self URL. This is standard practice for API responses.
+      self: `/rest/api/2/issue/${issueKey}`,
+      fields: {
+          project: { key: data.projectKey },
+          issuetype: { id: data.issueTypeId }, // Using issue type ID as per JIRA API
+          summary: data.summary,
+          description: data.description,
+          // Add default values for common fields required by the Issue interface or API spec
+          status: { id: '1', name: 'To Do' }, // Default initial status for new issues
+          created: new Date().toISOString(), // Set creation timestamp
+          updated: new Date().toISOString(), // Set update timestamp
+      }
+  };
+
+  // 4. Add the new issue to the database and update the counter
+  db.issues.push(newIssue);
+  db.issueKeyCounter = newCounter;
+
+  // 5. Save the updated database state
+  await saveDatabase(db);
+
+  // 6. Return the newly created issue
+  // The newIssue object conforms to the Issue interface.
+  return newIssue;
+};


### PR DESCRIPTION
Completed implementation of the POST /rest/api/2/issue endpoint for issue ATM-1295.

This includes:
- Defining the API route `POST /rest/api/2/issue` in `src/api/routes/issueRoutes.ts`.
- Creating the `issueController.ts` in `src/api/controllers/` with a `createIssue` handler function.
- Implementing the `createIssue` function within `src/services/issueService.ts` which handles the business logic for creating an issue.
- The service layer now uses actual database persistence (`loadDatabase`, `saveDatabase`) for storing new issues.
- New issues are assigned a unique ID (UUID), a generated issue key, a relative `self` URL, creation/update timestamps, and a default status of 'To Do'.
- Input validation for required fields is handled in the controller (implemented in previous turns).
- Comments within the service layer have been refined to remove any placeholder or non-production-ready language.