### PR TITLE
ATM-1296: Implement Request Body Parsing and Validation

### DIFF
--- a/src/api/controllers/issue.test.ts
+++ b/src/api/controllers/issue.test.ts
@@ -1,12 +1,16 @@
 import request from 'supertest';
 import app from '../../app';
+import { createIssue as createIssueService } from '../../services/issueService';
+import { IssueType } from '../../models/issue';
+
+jest.mock('../../services/issueService');
 
 describe('issueController', () => {
   describe('POST /rest/api/2/issue', () => {
     const validPayload = {
       fields: {
         project: { key: 'TEST' },
-        issuetype: { id: '10002' },
+        issuetype: { name: 'Bug' },
         summary: 'This is a valid test issue summary',
         description: 'Optional description',
       },
@@ -18,15 +22,19 @@ describe('issueController', () => {
         .send(validPayload);
 
       expect(res.status).toBe(201);
-      // The controller currently returns a simple message, not the created issue details
-      expect(res.body).toEqual({ message: 'Issue creation request received' });
+      // The controller currently returns the created issue details
+      expect(res.body).toEqual({
+        id: expect.any(String),
+        key: expect.any(String),
+        self: expect.any(String),
+      });
     });
 
     test('should return 400 status if project key is missing', async () => {
       const invalidPayload = {
         fields: {
           project: { }, // Missing key inside project
-          issuetype: { id: '10002' },
+          issuetype: { name: 'Bug' },
           summary: 'This is a test issue summary',
         },
       };
@@ -39,11 +47,11 @@ describe('issueController', () => {
       expect(res.body).toEqual({ error: 'Project key is required' });
     });
 
-    test('should return 400 status if issue type ID is missing', async () => {
+    test('should return 400 status if issue type name is missing', async () => {
       const invalidPayload = {
         fields: {
           project: { key: 'TEST' },
-          issuetype: { }, // Missing id inside issuetype
+          issuetype: { }, // Missing name inside issuetype
           summary: 'This is a test issue summary',
         },
       };
@@ -53,14 +61,14 @@ describe('issueController', () => {
         .send(invalidPayload);
 
       expect(res.status).toBe(400);
-      expect(res.body).toEqual({ error: 'Issue type ID is required' });
+      expect(res.body).toEqual({ error: 'Issue type name is required' });
     });
 
     test('should return 400 status if summary is missing', async () => {
       const invalidPayload = {
         fields: {
           project: { key: 'TEST' },
-          issuetype: { id: '10002' },
+          issuetype: { name: 'Bug' },
           // summary is missing entirely
         },
       };
@@ -91,7 +99,7 @@ describe('issueController', () => {
       const invalidPayload = {
         fields: {
           // project is missing entirely
-          issuetype: { id: '10002' },
+          issuetype: { name: 'Bug' },
           summary: 'This is a test issue summary',
         },
       };
@@ -119,8 +127,77 @@ describe('issueController', () => {
         .send(invalidPayload);
 
       expect(res.status).toBe(400);
-      // The controller checks for fields?.issuetype?.id
-      expect(res.body).toEqual({ error: 'Issue type ID is required' });
+      // The controller checks for fields?.issuetype?.name
+      expect(res.body).toEqual({ error: 'Issue type name is required' });
+    });
+
+    test('should return 201 when parent key exists', async () => {
+      (createIssueService as jest.Mock).mockResolvedValueOnce({
+        id: '123',
+        key: 'TEST-1',
+        self: 'http://localhost:3000/rest/api/2/issue/123',
+      });
+      const payloadWithParent = {
+        fields: {
+          project: { key: 'TEST' },
+          issuetype: { name: 'Bug' },
+          summary: 'This is a test issue with a parent',
+          parent: { key: 'TEST-123' },
+        },
+      };
+
+      const res = await request(app)
+        .post('/rest/api/2/issue')
+        .send(payloadWithParent);
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual({
+        id: '123',
+        key: 'TEST-1',
+        self: 'http://localhost:3000/rest/api/2/issue/123',
+      });
+      expect(createIssueService).toHaveBeenCalledWith(expect.objectContaining({
+        parentKey: 'TEST-123',
+      }));
+    });
+
+    test('should return 500 when parent key does not exist', async () => {
+        (createIssueService as jest.Mock).mockRejectedValueOnce(new Error('Parent issue not found'));
+        const payloadWithParent = {
+            fields: {
+                project: { key: 'TEST' },
+                issuetype: { name: 'Bug' },
+                summary: 'This is a test issue with a non-existent parent',
+                parent: { key: 'TEST-999' },
+            },
+        };
+
+        const res = await request(app)
+            .post('/rest/api/2/issue')
+            .send(payloadWithParent);
+
+        expect(res.status).toBe(500);
+        expect(res.body).toEqual({ error: 'Failed to create issue' });
+        expect(createIssueService).toHaveBeenCalledWith(expect.objectContaining({
+            parentKey: 'TEST-999',
+        }));
+    });
+
+    test('should return 400 if issue type is invalid', async () => {
+      const invalidPayload = {
+        fields: {
+          project: { key: 'TEST' },
+          issuetype: { name: 'InvalidType' },
+          summary: 'This is a test issue summary',
+        },
+      };
+
+      const res = await request(app)
+        .post('/rest/api/2/issue')
+        .send(invalidPayload);
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'Invalid issue type' });
     });
   });
 });

--- a/src/api/controllers/issueController.ts
+++ b/src/api/controllers/issueController.ts
@@ -1,5 +1,8 @@
 import { Request, Response } from 'express';
 import { createIssue as createIssueService } from '../../services/issueService';
+import { IssueType } from '../../models/issue';
+
+const ALLOWED_ISSUE_TYPES = ['Bug', 'Story', 'Task', 'Epic', 'Subtask'];
 
 /**
  * Handles the creation of a new issue.
@@ -10,24 +13,33 @@ import { createIssue as createIssueService } from '../../services/issueService';
 export const createIssue = async (req: Request, res: Response): Promise<void> => {
   const { fields } = req.body;
 
-  if (!fields?.project?.key) {
+  if (!fields) {
+    return res.status(400).json({ error: 'Request body is required' });
+  }
+
+  if (!fields.project?.key) {
     return res.status(400).json({ error: 'Project key is required' });
   }
 
-  if (!fields?.issuetype?.id) {
-    return res.status(400).json({ error: 'Issue type ID is required' });
+  if (!fields.issuetype?.name) {
+    return res.status(400).json({ error: 'Issue type name is required' });
   }
 
-  if (!fields?.summary) {
+  if (!ALLOWED_ISSUE_TYPES.includes(fields.issuetype.name)) {
+    return res.status(400).json({ error: 'Invalid issue type' });
+  }
+
+  if (!fields.summary) {
     return res.status(400).json({ error: 'Summary is required' });
   }
 
   try {
     const createdIssue = await createIssueService({
       projectKey: fields.project.key,
-      issueTypeId: fields.issuetype.id,
+      issueTypeName: fields.issuetype.name as IssueType,
       summary: fields.summary,
       description: fields.description,
+      parentKey: fields.parent?.key,
     });
     res.status(201).json({
       id: createdIssue.id,


### PR DESCRIPTION
Implement request body parsing and validation for the create issue handler (ATM-1296).

This PR adds validation for the following fields in the request body:
- `fields` object existence
- `fields.project.key` existence
- `fields.issuetype.name` existence
- `fields.summary` existence
- `fields.issuetype.name` validation against a list of allowed types.

It also extracts and passes the `fields.parent?.key` to the issue creation service if provided.

Comprehensive unit tests have been added for the issue controller to cover these validation scenarios.