### PR TITLE
ATM-1297: Implement Issue Service Logic

### DIFF
--- a/src/issueService.test.ts
+++ b/src/issueService.test.ts
@@ -1,0 +1,238 @@
+import { createIssue } from './issueService';
+import { loadDatabase, saveDatabase } from './dataStore';
+import { DbSchema, AnyIssue } from './models'; // Assuming AnyIssue and DbSchema are exported from models
+
+// Mock the dataStore module to control database interactions
+jest.mock('./dataStore');
+
+const mockLoadDatabase = loadDatabase as jest.Mock;
+const mockSaveDatabase = saveDatabase as jest.Mock;
+
+describe('issueService', () => {
+  const initialDb: DbSchema = {
+    issues: [],
+    issueKeyCounter: 0,
+  };
+
+  let savedDbState: DbSchema | null = null;
+  let mockDate: Date;
+
+  beforeEach(() => {
+    // Reset mocks and mock data before each test
+    mockLoadDatabase.mockClear();
+    mockSaveDatabase.mockClear();
+    savedDbState = null;
+
+    // Mock loadDatabase to return a copy of the initial state
+    mockLoadDatabase.mockResolvedValue(JSON.parse(JSON.stringify(initialDb))); // Deep copy to avoid mutation issues
+
+    // Mock saveDatabase to capture the state it was called with
+    mockSaveDatabase.mockImplementation(async (db: DbSchema) => {
+      savedDbState = db; // Capture the state
+      return Promise.resolve();
+    });
+
+    // Mock Date to get predictable timestamps
+    mockDate = new Date('2023-10-27T10:00:00.000Z');
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate as any);
+  });
+
+  afterEach(() => {
+    // Restore Date mock
+    jest.restoreAllMocks();
+  });
+
+  it('should create an issue with default status and properties', async () => {
+    const input = {
+      title: 'Test Issue Title',
+      description: 'This is a test description.',
+    };
+
+    const createdIssue = await createIssue(input);
+
+    // Verify database interactions
+    expect(mockLoadDatabase).toHaveBeenCalledTimes(1);
+    expect(mockSaveDatabase).toHaveBeenCalledTimes(1);
+    expect(savedDbState).not.toBeNull(); // Ensure saveDatabase was called
+
+    // Verify the saved database state
+    expect(savedDbState!.issueKeyCounter).toBe(1);
+    expect(savedDbState!.issues.length).toBe(1);
+    const savedIssue = savedDbState!.issues[0];
+
+    // Verify the returned issue object
+    expect(createdIssue).toBeDefined();
+    expect(createdIssue.key).toBe('ISSUE-1');
+    expect(createdIssue.title).toBe(input.title);
+    expect(createdIssue.description).toBe(input.description);
+    expect(createdIssue.status).toBe('Open'); // Default status
+    expect(createdIssue.createdAt).toEqual(mockDate);
+    expect(createdIssue.updatedAt).toEqual(mockDate);
+    expect(createdIssue.parentKey).toBeUndefined(); // Should not have parentKey
+
+    // Verify the returned object matches the saved object (reference might differ, but properties should match)
+    expect(createdIssue).toEqual(savedIssue);
+  });
+
+  it('should create an issue with status Backlog when issueTypeName is feature', async () => {
+    const input = {
+      title: 'Feature Title',
+      description: 'This is a feature request.',
+      issueTypeName: 'feature',
+    };
+
+    const createdIssue = await createIssue(input);
+
+    expect(mockLoadDatabase).toHaveBeenCalledTimes(1);
+    expect(mockSaveDatabase).toHaveBeenCalledTimes(1);
+    expect(savedDbState).not.toBeNull();
+
+    expect(savedDbState!.issueKeyCounter).toBe(1);
+    expect(savedDbState!.issues.length).toBe(1);
+    const savedIssue = savedDbState!.issues[0];
+
+    expect(createdIssue.key).toBe('ISSUE-1');
+    expect(createdIssue.status).toBe('Backlog'); // Status should be Backlog
+
+    expect(createdIssue).toEqual(savedIssue);
+  });
+
+  it('should create an issue with status Open when issueTypeName is bug', async () => {
+    const input = {
+      title: 'Bug Title',
+      description: 'This is a bug report.',
+      issueTypeName: 'bug',
+    };
+
+    const createdIssue = await createIssue(input);
+
+    expect(mockLoadDatabase).toHaveBeenCalledTimes(1);
+    expect(mockSaveDatabase).toHaveBeenCalledTimes(1);
+    expect(savedDbState).not.toBeNull();
+
+    expect(savedDbState!.issueKeyCounter).toBe(1);
+    expect(savedDbState!.issues.length).toBe(1);
+    const savedIssue = savedDbState!.issues[0];
+
+    expect(createdIssue.key).toBe('ISSUE-1');
+    expect(createdIssue.status).toBe('Open'); // Status should be Open (explicitly set for bug)
+
+    expect(createdIssue).toEqual(savedIssue);
+  });
+
+  it('should create an issue with a parentKey if provided', async () => {
+    const input = {
+      title: 'Subtask Title',
+      description: 'This is a subtask.',
+      parentKey: 'EPIC-123',
+    };
+
+    const createdIssue = await createIssue(input);
+
+    expect(mockLoadDatabase).toHaveBeenCalledTimes(1);
+    expect(mockSaveDatabase).toHaveBeenCalledTimes(1);
+    expect(savedDbState).not.toBeNull();
+
+    expect(savedDbState!.issueKeyCounter).toBe(1);
+    expect(savedDbState!.issues.length).toBe(1);
+    const savedIssue = savedDbState!.issues[0];
+
+    expect(createdIssue.key).toBe('ISSUE-1');
+    expect(createdIssue.title).toBe(input.title);
+    expect(createdIssue.description).toBe(input.description);
+    expect(createdIssue.parentKey).toBe('EPIC-123'); // Parent key should be present
+
+    expect(createdIssue).toEqual(savedIssue);
+  });
+
+  it('should generate the next key correctly when counter is not zero', async () => {
+    const dbWithExistingIssues: DbSchema = {
+      issues: [
+        // Mock existing issues
+        {
+          key: 'ISSUE-10',
+          title: 'Existing Issue',
+          description: '...',
+          status: 'Done',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          id: 'uuid1', issueType: 'Task', summary: '...',
+        },
+      ],
+      issueKeyCounter: 10, // Start counter from 10
+    };
+
+    mockLoadDatabase.mockResolvedValue(JSON.parse(JSON.stringify(dbWithExistingIssues)));
+
+    const input = {
+      title: 'New Issue After 10',
+      description: '...',
+    };
+
+    const createdIssue = await createIssue(input);
+
+    expect(mockLoadDatabase).toHaveBeenCalledTimes(1);
+    expect(mockSaveDatabase).toHaveBeenCalledTimes(1);
+    expect(savedDbState).not.toBeNull();
+
+    expect(savedDbState!.issueKeyCounter).toBe(11); // Counter should be 11
+    expect(savedDbState!.issues.length).toBe(2); // Should contain both issues
+    expect(createdIssue.key).toBe('ISSUE-11'); // New key should be ISSUE-11
+
+    // Check the newly added issue in saved state
+    const newSavedIssue = savedDbState!.issues.find(issue => issue.key === 'ISSUE-11');
+    expect(newSavedIssue).toBeDefined();
+    expect(newSavedIssue!.title).toBe(input.title);
+    expect(newSavedIssue!.description).toBe(input.description);
+
+    expect(createdIssue).toEqual(newSavedIssue);
+  });
+
+  it('should throw an error if database loading fails', async () => {
+    const mockError = new Error('Failed to load database');
+    mockLoadDatabase.mockRejectedValue(mockError);
+
+    const input = {
+      title: 'Issue to Fail',
+      description: '...',
+    };
+
+    await expect(createIssue(input)).rejects.toThrow('Failed to create issue due to a data storage error.');
+
+    expect(mockLoadDatabase).toHaveBeenCalledTimes(1);
+    expect(mockSaveDatabase).not.toHaveBeenCalled(); // Save should not be called if load fails
+  });
+
+  it('should throw an error if database saving fails', async () => {
+    const mockError = new Error('Failed to save database');
+    mockSaveDatabase.mockRejectedValue(mockError);
+
+    const input = {
+      title: 'Issue to Fail Save',
+      description: '...',
+    };
+
+    await expect(createIssue(input)).rejects.toThrow('Failed to create issue due to a data storage error.');
+
+    expect(mockLoadDatabase).toHaveBeenCalledTimes(1);
+    expect(mockSaveDatabase).toHaveBeenCalledTimes(1); // Save should be attempted
+  });
+
+  it('should include createdAt and updatedAt timestamps', async () => {
+    const input = {
+      title: 'Timestamp Test',
+      description: 'Checking timestamps',
+    };
+
+    const createdIssue = await createIssue(input);
+
+    expect(createdIssue.createdAt).toEqual(mockDate);
+    expect(createdIssue.updatedAt).toEqual(mockDate);
+
+    // Check saved state too
+    expect(savedDbState).not.toBeNull();
+    const savedIssue = savedDbState!.issues[0];
+    expect(savedIssue.createdAt).toEqual(mockDate);
+    expect(savedIssue.updatedAt).toEqual(mockDate);
+  });
+});

--- a/src/issueService.ts
+++ b/src/issueService.ts
@@ -1,0 +1,128 @@
+import { loadDatabase, saveDatabase, DbSchema, AnyIssue } from './dataStore';
+import { v4 as uuidv4 } from 'uuid'; // Import uuid generator
+
+// Define the input type for creating an issue.
+// This specifies the data required from the caller to create a new issue.
+interface IssueInput {
+  title: string;
+  description?: string; // Description is optional based on AnyIssue
+  issueTypeName?: string; // Optional type for the issue
+  parentKey?: string | null; // Optional reference to a parent issue key
+  // Add other properties required for issue creation, excluding internal ones like key or fixed initial status.
+}
+
+/**
+ * Creates a new issue in the database.
+ * It generates a unique key and id, sets initial properties based on input
+ * and AnyIssue interface requirements, adds the issue to the database,
+ * updates the key counter, and saves the database.
+ *
+ * @param input - An object containing the initial properties for the new issue (e.g., title, description, type).
+ * @returns A promise that resolves with the newly created issue object, adhering to the AnyIssue interface.
+ * @throws {Error} If any database operation fails during the process.
+ */
+export async function createIssue(input: IssueInput): Promise<AnyIssue> {
+  try {
+    // 1. Load the database
+    const db: DbSchema = await loadDatabase();
+
+    // 2. Generate a new issue key by incrementing issueKeyCounter
+    const newIssueKeyCounter = db.issueKeyCounter + 1;
+    // Format the counter into a unique key string, e.g., "ISSUE-1", "ISSUE-2", etc.
+    const newIssueKey = `ISSUE-${newIssueKeyCounter}`;
+
+    // 3. Create a new issue object adhering to AnyIssue
+    const now = new Date();
+    const newIssueId = uuidv4(); // Generate a unique UUID for id
+
+    // Map issueTypeName from input to AnyIssue['issueType'], ensuring it's one of the allowed types.
+    let issueType: AnyIssue['issueType'];
+    switch (input.issueTypeName) {
+      case 'Task':
+        issueType = 'Task';
+        break;
+      case 'Story':
+      case 'feature': // Allow 'feature' as an alias for 'Story'
+        issueType = 'Story';
+        break;
+      case 'Epic':
+        issueType = 'Epic';
+        break;
+      case 'Bug':
+        issueType = 'Bug';
+        break;
+      case 'Subtask':
+        issueType = 'Subtask';
+        break;
+      default:
+        issueType = 'Task'; // Default to 'Task' if input type is unrecognized or not provided
+    }
+
+    // Determine initial status based on the mapped issueType, ensuring it's one of the allowed types ('Todo', 'In Progress', 'Done').
+    let status: AnyIssue['status'];
+    if (issueType === 'Bug') {
+        status = 'In Progress'; // Bug issues start as 'In Progress'
+    } else {
+        status = 'Todo'; // All other issue types (Task, Story, Epic, Subtask) start as 'Todo'
+    }
+
+    // Construct the base issue object, strictly adhering to the BaseIssue interface properties.
+    // This includes all required fields from BaseIssue.
+    const baseIssue: BaseIssue = {
+      id: newIssueId, // UUID generated for the issue
+      key: newIssueKey, // Unique key derived from the counter
+      issueType: issueType, // Determined issue type
+      summary: input.title, // Issue title from input, mapped to summary
+      description: input.description, // Optional description from input
+      status: status, // Initial status determined based on issue type
+      createdAt: now.toISOString(), // Timestamp of creation (ISO string)
+      updatedAt: now.toISOString(), // Timestamp of last update (initially same as createdAt)
+      parentKey: input.parentKey ?? null, // Optional parent issue key from input, ensure null or undefined becomes null
+    };
+
+    // Add type-specific properties based on the determined issueType,
+    // ensuring the final object adheres to the specific concrete interface (Task, Story, Epic, Bug, Subtask)
+    // and thus the AnyIssue union type.
+    let newIssue: AnyIssue;
+
+    if (issueType === 'Epic') {
+      newIssue = {
+        ...baseIssue,
+        issueType: 'Epic', // Explicitly set for type narrowing
+        childIssueKeys: [], // Epics start with no children
+      } as Epic; // Cast to Epic type to satisfy interface
+    } else if (issueType === 'Subtask') {
+      // Subtasks require a parentIssueKey which must come from input.parentKey
+      if (!input.parentKey) {
+        throw new Error('Subtask creation requires a parentKey.');
+      }
+      newIssue = {
+        ...baseIssue,
+        issueType: 'Subtask', // Explicitly set for type narrowing
+        parentIssueKey: input.parentKey, // Required for Subtasks
+      } as Subtask; // Cast to Subtask type to satisfy interface
+    } else {
+      // Task, Story, Bug issues only have BaseIssue properties (plus optional description/parentKey)
+      // Cast to AnyIssue to be safe, although it should implicitly fit Task/Story/Bug which extend BaseIssue
+      newIssue = baseIssue as Task | Story | Bug;
+    }
+
+    // 4. Add the new issue to the issues array in the database
+    db.issues.push(newIssue);
+
+    // 5. Increment issueKeyCounter in the database
+    db.issueKeyCounter = newIssueKeyCounter;
+
+    // 6. Save the updated database
+    await saveDatabase(db);
+
+    // 7. Return the newly created issue
+    return newIssue;
+
+  } catch (error) {
+    // Log the error internally for debugging purposes
+    console.error('Error creating issue:', error);
+    // Re-throw a standardized error message or the original error
+    throw new Error('Failed to create issue due to a data storage error.');
+  }
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -12,6 +12,7 @@ interface BaseIssue {
   status: "Todo" | "In Progress" | "Done";
   createdAt: string; // ISO8601
   updatedAt: string; // ISO8601
+  parentKey?: string | null; // Optional reference to a parent issue key
 }
 
 // EpicSpecifics


### PR DESCRIPTION
Implement `createIssue` function in `issueService.ts`.

This commit adds the `createIssue` function as per the task requirements. The function handles loading the database, generating a unique issue key and ID, setting timestamps, mapping issue types and setting initial status based on `models.ts` definitions, constructing the issue object adhering to the `AnyIssue` interface (including type-specific properties for Epic and Subtask), handling parent keys, and saving the database. This addresses the issues identified in the previous review regarding data model adherence.