### PR TITLE
ATM-1307: Implement Logging for Issue Creation API

### DIFF
--- a/src/api/controllers/createIssue.logging.test.ts
+++ b/src/api/controllers/createIssue.logging.test.ts
@@ -1,0 +1,309 @@
+// src/api/controllers/createIssue.logging.test.ts
+import { Request, Response } from 'express';
+import { createIssue as createIssueController } from './createIssue';
+import * as issueServiceModule from '../../issueService';
+import logger from '../../utils/logger';
+import { IssueCreationError, IssueErrorCodes } from '../../utils/errorHandling';
+import { AnyIssue, CreateIssueInput } from '../../models';
+
+// Mock logger
+// We are mocking the default export which is an object with info, warn, error methods
+jest.mock('../../utils/logger', () => ({
+  __esModule: true, // ES Module mock
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(), // Include warn for completeness, though not used by this controller
+    error: jest.fn(),
+  },
+}));
+
+// Mock issueService
+// We are mocking the named export 'createIssue' from this module
+jest.mock('../../issueService', () => ({
+  __esModule: true, // ES Module mock
+  createIssue: jest.fn(),
+}));
+
+// Type cast the mocked logger methods
+const mockedLoggerInfo = logger.info as jest.Mock;
+const mockedLoggerError = logger.error as jest.Mock;
+
+// Type cast the mocked service function
+const mockedServiceCreateIssue = issueServiceModule.createIssue as jest.MockedFunction<
+  typeof issueServiceModule.createIssue
+>;
+
+// Helper to create a mock Express Response object
+const createMockResponse = (): Response => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn().mockReturnThis();
+  res.send = jest.fn().mockReturnThis(); // .send() is not used by controller in these paths, but good for a generic mock
+  return res as Response;
+};
+
+// Interface for the request body as expected by the controller
+// Duplicating this interface here for test clarity and independence.
+interface IncomingCreateIssueRequestBody {
+  fields: {
+    summary: string;
+    description?: string;
+    issuetype: {
+      name: string;
+    };
+    parent?: {
+      key: string;
+    };
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
+
+describe('createIssue Controller - Logging', () => {
+  let mockReq: Request;
+  let mockRes: Response;
+
+  beforeEach(() => {
+    // Reset mocks before each test to clear call history and mock implementations
+    mockedLoggerInfo.mockReset();
+    mockedLoggerError.mockReset();
+    mockedServiceCreateIssue.mockReset();
+
+    mockRes = createMockResponse(); // Create a fresh response mock for each test
+  });
+
+  describe('Successful Creation', () => {
+    it('should call all logger.info methods with correct messages and data in the success path', async () => {
+      const requestBody: IncomingCreateIssueRequestBody = {
+        fields: {
+          summary: 'Test Issue Summary',
+          description: 'Detailed description of the test issue.',
+          issuetype: { name: 'Task' },
+          parent: { key: 'PARENT-ISSUE-1' },
+        },
+      };
+      mockReq = { body: requestBody, params: {}, query: {} } as Request;
+
+      const expectedServiceInput: CreateIssueInput = {
+        title: requestBody.fields.summary,
+        issueTypeName: requestBody.fields.issuetype.name,
+        description: requestBody.fields.description,
+        parentKey: requestBody.fields.parent?.key,
+      };
+
+      const now = new Date().toISOString();
+      const mockCreatedIssue: AnyIssue = {
+        id: 'test-id-123',
+        key: 'TEST-1',
+        issueType: 'Task',
+        summary: requestBody.fields.summary,
+        description: requestBody.fields.description,
+        status: 'Todo',
+        createdAt: now,
+        updatedAt: now,
+        parentKey: requestBody.fields.parent?.key,
+      };
+      mockedServiceCreateIssue.mockResolvedValue(mockCreatedIssue);
+
+      const expectedResponseBody = {
+        id: mockCreatedIssue.id,
+        key: mockCreatedIssue.key,
+        issueType: { name: mockCreatedIssue.issueType as string },
+        summary: mockCreatedIssue.summary,
+        description: mockCreatedIssue.description,
+        status: { name: mockCreatedIssue.status as string },
+        createdAt: mockCreatedIssue.createdAt,
+        updatedAt: mockCreatedIssue.updatedAt,
+        self: `/rest/api/2/issue/${mockCreatedIssue.key}`,
+      };
+
+      await createIssueController(mockReq, mockRes);
+
+      expect(mockedLoggerInfo).toHaveBeenCalledTimes(6);
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue Controller: Start processing request.');
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue Controller: Received body:', { body: requestBody });
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(3, 'createIssue Controller: Input passed to service:', { input: expectedServiceInput });
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(4, 'createIssue Controller: Service call successful.');
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(5, 'createIssue Controller: Constructed Response Body:', { response: expectedResponseBody });
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(6, 'createIssue Controller: Successfully created issue.', { issueKey: mockCreatedIssue.key });
+
+      expect(mockedLoggerError).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(201);
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponseBody);
+    });
+  });
+
+  describe('Invalid Request Body (Missing fields)', () => {
+    it('should call logger.error with INVALID_INPUT and log caught error', async () => {
+      const requestBody = {}; // Missing 'fields'
+      // Use 'as any' for type flexibility in test setup, controller handles untyped input
+      mockReq = { body: requestBody, params: {}, query: {} } as any;
+
+      await createIssueController(mockReq, mockRes);
+
+      expect(mockedLoggerInfo).toHaveBeenCalledTimes(2);
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue Controller: Start processing request.');
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue Controller: Received body:', { body: requestBody });
+
+      expect(mockedLoggerError).toHaveBeenCalledTimes(2);
+      // First error log: Validation specific
+      expect(mockedLoggerError).toHaveBeenNthCalledWith(1,
+        "IssueCreationError during validation: Invalid request body format.",
+        { error: IssueErrorCodes.INVALID_INPUT, statusCode: 400, body: requestBody }
+      );
+      // Second error log: From the catch block
+      expect(mockedLoggerError).toHaveBeenNthCalledWith(2,
+        "Caught IssueCreationError:",
+        {
+          error: "Invalid request body format.", // Message from the thrown IssueCreationError
+          code: IssueErrorCodes.INVALID_INPUT,
+          status: 400,
+        }
+      );
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('Invalid Request Body (Missing summary)', () => {
+    it('should call logger.error with MISSING_TITLE and log caught error', async () => {
+      const requestBody = {
+        fields: {
+          // summary is missing
+          issuetype: { name: 'Bug' },
+        },
+      };
+      mockReq = { body: requestBody, params: {}, query: {} } as any; // Cast for test purposes
+
+      await createIssueController(mockReq, mockRes);
+
+      expect(mockedLoggerInfo).toHaveBeenCalledTimes(2);
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue Controller: Start processing request.');
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue Controller: Received body:', { body: requestBody });
+
+      expect(mockedLoggerError).toHaveBeenCalledTimes(2);
+      expect(mockedLoggerError).toHaveBeenNthCalledWith(1,
+        "IssueCreationError during validation: Missing or invalid 'summary'.",
+        { error: IssueErrorCodes.MISSING_TITLE, statusCode: 400, body: requestBody }
+      );
+      expect(mockedLoggerError).toHaveBeenNthCalledWith(2,
+        "Caught IssueCreationError:",
+        {
+          error: "Missing or invalid 'summary' in request fields.",
+          code: IssueErrorCodes.MISSING_TITLE,
+          status: 400,
+        }
+      );
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('Invalid Request Body (Missing issuetype name)', () => {
+    it('should call logger.error with INVALID_ISSUE_TYPE and log caught error', async () => {
+      const requestBody = {
+        fields: {
+          summary: 'A valid summary',
+          issuetype: { /* name is missing */ },
+        },
+      };
+      mockReq = { body: requestBody, params: {}, query: {} } as any; // Cast for test purposes
+
+      await createIssueController(mockReq, mockRes);
+
+      expect(mockedLoggerInfo).toHaveBeenCalledTimes(2);
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue Controller: Start processing request.');
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue Controller: Received body:', { body: requestBody });
+
+      expect(mockedLoggerError).toHaveBeenCalledTimes(2);
+      expect(mockedLoggerError).toHaveBeenNthCalledWith(1,
+        "IssueCreationError during validation: Missing or invalid 'issuetype' name.",
+        { error: IssueErrorCodes.INVALID_ISSUE_TYPE, statusCode: 400, body: requestBody }
+      );
+      expect(mockedLoggerError).toHaveBeenNthCalledWith(2,
+        "Caught IssueCreationError:",
+        {
+          error: "Missing or invalid 'issuetype' name in request fields.",
+          code: IssueErrorCodes.INVALID_ISSUE_TYPE,
+          status: 400,
+        }
+      );
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('Service Throws IssueCreationError', () => {
+    it('should log preceding info messages and the caught IssueCreationError', async () => {
+      const requestBody: IncomingCreateIssueRequestBody = {
+        fields: {
+          summary: 'Service Error Test',
+          issuetype: { name: 'Story' },
+        },
+      };
+      mockReq = { body: requestBody, params: {}, query: {} } as Request;
+
+      const expectedServiceInput: CreateIssueInput = {
+        title: requestBody.fields.summary,
+        issueTypeName: requestBody.fields.issuetype.name,
+        description: undefined, // No description provided in this requestBody
+        parentKey: undefined,   // No parent provided in this requestBody
+      };
+
+      const serviceError = new IssueCreationError("Service layer error", "SERVICE_FAIL_CODE", 409);
+      mockedServiceCreateIssue.mockRejectedValue(serviceError);
+
+      await createIssueController(mockReq, mockRes);
+
+      expect(mockedLoggerInfo).toHaveBeenCalledTimes(3); // Start, Received body, Input to service
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue Controller: Start processing request.');
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue Controller: Received body:', { body: requestBody });
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(3, 'createIssue Controller: Input passed to service:', { input: expectedServiceInput });
+
+      expect(mockedLoggerError).toHaveBeenCalledTimes(1);
+      expect(mockedLoggerError).toHaveBeenCalledWith(
+        "Caught IssueCreationError:",
+        {
+          error: serviceError.message,
+          code: serviceError.errorCode,
+          status: serviceError.statusCode,
+        }
+      );
+      expect(mockRes.status).toHaveBeenCalledWith(409);
+    });
+  });
+
+  describe('Service Throws Unexpected Error', () => {
+    it('should log preceding info messages and the unexpected error object', async () => {
+      const requestBody: IncomingCreateIssueRequestBody = {
+        fields: {
+          summary: 'Unexpected Error Test',
+          issuetype: { name: 'Epic' },
+        },
+      };
+      mockReq = { body: requestBody, params: {}, query: {} } as Request;
+
+      const expectedServiceInput: CreateIssueInput = {
+        title: requestBody.fields.summary,
+        issueTypeName: requestBody.fields.issuetype.name,
+        description: undefined, // No description provided
+        parentKey: undefined,   // No parent provided
+      };
+
+      const unexpectedError = new Error("Something went very wrong!");
+      mockedServiceCreateIssue.mockRejectedValue(unexpectedError);
+
+      await createIssueController(mockReq, mockRes);
+
+      expect(mockedLoggerInfo).toHaveBeenCalledTimes(3); // Start, Received body, Input to service
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue Controller: Start processing request.');
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue Controller: Received body:', { body: requestBody });
+      expect(mockedLoggerInfo).toHaveBeenNthCalledWith(3, 'createIssue Controller: Input passed to service:', { input: expectedServiceInput });
+
+      expect(mockedLoggerError).toHaveBeenCalledTimes(1);
+      expect(mockedLoggerError).toHaveBeenCalledWith(
+        "Unexpected error in createIssue controller:",
+        unexpectedError // The actual error object is expected here
+      );
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/src/issueService.create.logging.test.ts
+++ b/src/issueService.create.logging.test.ts
@@ -1,0 +1,267 @@
+// src/issueService.create.logging.test.ts
+
+import { createIssue } from './issueService'; // Corrected path
+import logger from './utils/logger'; // Corrected path
+import { loadDatabase, saveDatabase } from './database/database'; // Corrected path
+import * as keyGenerator from './utils/keyGenerator'; // Corrected path
+import { v4 as uuidv4 } from 'uuid';
+import { DbSchema, CreateIssueInput, Task, Story, Epic, AnyIssue } from './models'; // Corrected path
+import { IssueCreationError } from './utils/errorHandling'; // Corrected path
+
+// Mock definitions
+jest.mock('./utils/logger', () => ({ // Corrected path
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('./database/database', () => ({ // Corrected path
+  loadDatabase: jest.fn(),
+  saveDatabase: jest.fn(),
+  DB_FILE_PATH: '/test/db.json', // Mocked, though not directly used by createIssue
+}));
+
+jest.mock('./utils/keyGenerator', () => ({ // Corrected path
+  generateIssueKey: jest.fn(),
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(),
+}));
+
+// Mock type assertions for TypeScript
+const mockLoggerInfo = logger.info as jest.Mock;
+const mockLoggerWarn = logger.warn as jest.Mock;
+const mockLoggerError = logger.error as jest.Mock;
+const mockLoadDatabase = loadDatabase as jest.Mock;
+const mockSaveDatabase = saveDatabase as jest.Mock;
+const mockGenerateIssueKey = keyGenerator.generateIssueKey as jest.Mock;
+const mockUuidv4 = uuidv4 as jest.Mock;
+
+
+describe('createIssue Logging', () => {
+  const baseDbSchema: DbSchema = {
+    issues: [],
+    issueKeyCounter: 0,
+  };
+
+  const defaultIssueInput: CreateIssueInput = {
+    title: 'Test Issue',
+    description: 'A test description',
+    issueTypeName: 'Task',
+  };
+
+  beforeEach(() => {
+    mockLoggerInfo.mockReset();
+    mockLoggerWarn.mockReset();
+    mockLoggerError.mockReset();
+    mockLoadDatabase.mockReset();
+    mockSaveDatabase.mockReset();
+    mockGenerateIssueKey.mockReset();
+    mockUuidv4.mockReset();
+
+    // Default successful mock implementations
+    mockLoadDatabase.mockResolvedValue(JSON.parse(JSON.stringify(baseDbSchema))); // Deep copy
+    mockSaveDatabase.mockResolvedValue(undefined);
+    mockGenerateIssueKey.mockResolvedValue('TEST-1'); // Default key
+    mockUuidv4.mockReturnValue('test-uuid'); // Default UUID
+  });
+
+  it('should log correctly on successful issue creation', async () => {
+    const input: CreateIssueInput = {
+      title: 'Successful Story',
+      description: 'This story should be created successfully.',
+      issueTypeName: 'Story', // Test a non-default type
+    };
+    const generatedKey = 'STOR-0'; // Expected key for Story with counter 0
+    mockGenerateIssueKey.mockResolvedValue(generatedKey);
+
+    await createIssue(input);
+
+    expect(mockLoggerInfo).toHaveBeenCalledTimes(8);
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue: Starting issue creation process', { input });
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue: Loading database...');
+    expect(mockLoadDatabase).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(3, 'createIssue: Database loaded successfully.');
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(4, 'createIssue: Generating issue key', { issueType: 'Story' });
+    expect(keyGenerator.generateIssueKey).toHaveBeenCalledWith(baseDbSchema.issueKeyCounter, 'Story');
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(5, 'createIssue: Issue key generated successfully', { newIssueKey: generatedKey });
+    expect(mockUuidv4).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(6, 'createIssue: Saving database', { issueKey: generatedKey });
+    expect(mockSaveDatabase).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(7, 'createIssue: Database saved successfully', { issueKey: generatedKey });
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(8, 'createIssue: Issue created successfully', { issueKey: generatedKey });
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it('should log warning and error for missing title', async () => {
+    const input: CreateIssueInput = { ...defaultIssueInput, title: '' };
+    const expectedError = new IssueCreationError('Issue title is required.', 'MISSING_TITLE', 400);
+
+    await expect(createIssue(input)).rejects.toThrow(expectedError);
+
+    expect(mockLoggerInfo).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenCalledWith('createIssue: Starting issue creation process', { input });
+
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn).toHaveBeenCalledWith('createIssue: Validation failed - Missing title', { input });
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).toHaveBeenCalledWith('createIssue: Error during issue creation', {
+      error: expect.objectContaining({
+        name: expectedError.name,
+        message: expectedError.message,
+        errorCode: expectedError.errorCode,
+        statusCode: expectedError.statusCode,
+      })
+    });
+  });
+
+  it('should log warning and error for missing parentKey for Subtask', async () => {
+    const input: CreateIssueInput = {
+      title: 'Subtask without parent',
+      issueTypeName: 'Subtask',
+      parentKey: undefined,
+    };
+    const expectedError = new IssueCreationError('Subtask creation requires a parentKey.', 'INVALID_PARENT_KEY', 400);
+
+    await expect(createIssue(input)).rejects.toThrow(expectedError);
+
+    expect(mockLoggerInfo).toHaveBeenCalledTimes(3); // Start, Load DB, DB Loaded
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue: Starting issue creation process', { input });
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue: Loading database...');
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(3, 'createIssue: Database loaded successfully.');
+
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn).toHaveBeenCalledWith('createIssue: Validation failed - Missing parentKey for subtask', { input });
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).toHaveBeenCalledWith('createIssue: Error during issue creation', {
+      error: expect.objectContaining({
+        name: expectedError.name,
+        message: expectedError.message,
+        errorCode: expectedError.errorCode,
+        statusCode: expectedError.statusCode,
+      })
+    });
+  });
+
+  it('should log warning and error if parent issue is not found for Subtask', async () => {
+    const parentKey = 'NON-EXISTENT-EPIC-1';
+    const input: CreateIssueInput = {
+      title: 'Subtask with missing parent',
+      issueTypeName: 'Subtask',
+      parentKey: parentKey,
+    };
+    // loadDatabase returns baseDbSchema (empty issues array) by default
+    const expectedError = new IssueCreationError(`Parent issue with key '${parentKey}' not found.`, 'PARENT_NOT_FOUND', 404);
+
+    await expect(createIssue(input)).rejects.toThrow(expectedError);
+
+    expect(mockLoggerInfo).toHaveBeenCalledTimes(3); // Start, Load DB, DB Loaded
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue: Starting issue creation process', { input });
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue: Loading database...');
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(3, 'createIssue: Database loaded successfully.');
+
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn).toHaveBeenCalledWith('createIssue: Validation failed - Parent not found', { parentKey });
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).toHaveBeenCalledWith('createIssue: Error during issue creation', {
+      error: expect.objectContaining({
+        name: expectedError.name,
+        message: expectedError.message,
+        errorCode: expectedError.errorCode, // Matches 'PARENT_NOT_FOUND' string from service
+        statusCode: expectedError.statusCode,
+      })
+    });
+  });
+
+  it('should log warning and error if parent issue type is invalid for Subtask', async () => {
+    const parentTaskKey = 'TASK-P1';
+    const dbWithInvalidParent: DbSchema = {
+      issues: [
+        {
+          id: 'parent-task-id',
+          key: parentTaskKey,
+          issueType: 'Task',
+          summary: 'Parent Task',
+          status: 'Todo',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        } as Task, // Casting to Task, BaseIssue props are sufficient for this test
+      ],
+      issueKeyCounter: 1,
+    };
+    mockLoadDatabase.mockResolvedValue(JSON.parse(JSON.stringify(dbWithInvalidParent)));
+
+    const input: CreateIssueInput = {
+      title: 'Subtask with invalid parent type',
+      issueTypeName: 'Subtask',
+      parentKey: parentTaskKey,
+    };
+    const expectedErrorMessage = `Issue with key '${parentTaskKey}' has type 'Task', which cannot be a parent of a Subtask. Only Epic or Story issues can be parents of Subtasks.`;
+    const expectedError = new IssueCreationError(expectedErrorMessage, 'INVALID_PARENT_TYPE', 400);
+
+    await expect(createIssue(input)).rejects.toThrow(expectedError);
+
+    expect(mockLoggerInfo).toHaveBeenCalledTimes(3); // Start, Load DB, DB Loaded
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue: Starting issue creation process', { input });
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue: Loading database...');
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(3, 'createIssue: Database loaded successfully.');
+
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn).toHaveBeenCalledWith('createIssue: Validation failed - Invalid parent type', { parentKey: parentTaskKey, parentType: 'Task' });
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).toHaveBeenCalledWith('createIssue: Error during issue creation', {
+      error: expect.objectContaining({
+        name: expectedError.name,
+        message: expectedError.message,
+        errorCode: expectedError.errorCode,
+        statusCode: expectedError.statusCode,
+      })
+    });
+  });
+
+
+  it('should log error correctly for a generic error during database load', async () => {
+    const dbError = new Error('Database load failure');
+    mockLoadDatabase.mockRejectedValue(dbError);
+    const expectedWrappedError = new Error(`Failed to create issue: ${dbError.message}`);
+
+    await expect(createIssue(defaultIssueInput)).rejects.toThrow(expectedWrappedError);
+
+    expect(mockLoggerInfo).toHaveBeenCalledTimes(2); // Start, Load DB
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue: Starting issue creation process', { input: defaultIssueInput });
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue: Loading database...');
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    // The error logged is the original dbError
+    expect(mockLoggerError).toHaveBeenCalledWith('createIssue: Error during issue creation', { error: dbError });
+  });
+
+  it('should log error correctly for a generic error during database save', async () => {
+    const dbSaveError = new Error('Database save failure');
+    mockSaveDatabase.mockRejectedValue(dbSaveError);
+    const expectedWrappedError = new Error(`Failed to create issue: ${dbSaveError.message}`);
+    const generatedKey = 'TEST-1'; // From default mockGenerateIssueKey
+
+    await expect(createIssue(defaultIssueInput)).rejects.toThrow(expectedWrappedError);
+
+    // Logs up to "Saving database"
+    expect(mockLoggerInfo).toHaveBeenCalledTimes(6); // Start, Load, Loaded, Gen Key, Key Gen Success, Saving DB
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(1, 'createIssue: Starting issue creation process', { input: defaultIssueInput });
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(2, 'createIssue: Loading database...');
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(3, 'createIssue: Database loaded successfully.');
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(4, 'createIssue: Generating issue key', { issueType: defaultIssueInput.issueTypeName }); // 'Task'
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(5, 'createIssue: Issue key generated successfully', { newIssueKey: generatedKey });
+    expect(mockLoggerInfo).toHaveBeenNthCalledWith(6, 'createIssue: Saving database', { issueKey: generatedKey });
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    // The error logged is the original dbSaveError
+    expect(mockLoggerError).toHaveBeenCalledWith('createIssue: Error during issue creation', { error: dbSaveError });
+  });
+});


### PR DESCRIPTION
Implement structured logging in the `createIssue` controller and service methods to track the issue creation process. This includes logging incoming request data, key generation, database load/save operations, errors, and the final successful response object. Comprehensive unit tests have been added for both the controller and service layers to verify logging behaviour in success, validation error, and other error scenarios.