### PR TITLE
ATM-1295: Implement API Route and Controller Setup

### DIFF
--- a/src/api/controllers/issueController.ts
+++ b/src/api/controllers/issueController.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+
+/**
+ * Placeholder controller function to create an issue.
+ * This logs a message and sends a 201 response.
+ *
+ * @param req - The Express request object.
+ * @param res - The Express response object.
+ */
+export const createIssue = async (req: Request, res: Response): Promise<void> => {
+  console.log('Placeholder: createIssue controller called');
+
+  // Generate mock data for now
+  const mockIssueResponse = {
+    id: '10000', // Mock ID
+    key: 'PROJ-1', // Mock Key
+    self: 'http://localhost:3000/rest/api/2/issue/10000' // Mock URL
+  };
+
+  res.status(201).json(mockIssueResponse);
+};

--- a/src/api/routes/issueRoutes.ts
+++ b/src/api/routes/issueRoutes.ts
@@ -1,0 +1,65 @@
+import { Router } from 'express';
+import { createIssue } from '../controllers/issueController'; // Assuming controller is in ../controllers
+
+const router = Router();
+
+/**
+ * @swagger
+ * /rest/api/2/issue:
+ *   post:
+ *     summary: Create a new issue
+ *     tags:
+ *       - Issues
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               // Define the expected properties for creating an issue
+ *               // This is a placeholder; replace with actual schema details
+ *               summary:
+ *                 type: string
+ *                 description: The summary of the issue.
+ *                 example: "Fix bug in user profile"
+ *               description:
+ *                 type: string
+ *                 description: The detailed description of the issue.
+ *                 example: "When clicking on the edit profile button, the form does not load."
+ *               projectKey:
+ *                 type: string
+ *                 description: The key of the project the issue belongs to.
+ *                 example: "PROJ"
+ *               issueType:
+ *                 type: string
+ *                 description: The type of the issue (e.g., Bug, Task, Story).
+ *                 example: "Bug"
+ *               // Add other relevant fields like priority, assignee, etc.
+ *     responses:
+ *       201:
+ *         description: Issue created successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 // Define the properties of the response object
+ *                 // This is a placeholder; replace with actual response structure
+ *                 id:
+ *                   type: string
+ *                   description: The ID of the created issue.
+ *                 key:
+ *                   type: string
+ *                   description: The key of the created issue.
+ *                 self:
+ *                   type: string
+ *                   description: The URL of the created issue.
+ *       400:
+ *         description: Bad request (e.g., missing required fields, invalid data)
+ *       500:
+ *         description: Internal server error
+ */
+router.post('/rest/api/2/issue', createIssue);
+
+export default router;

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -7,3 +7,42 @@ describe('GET /', () => {
     expect(response.statusCode).toBe(200);
   });
 });
+
+describe('POST /rest/api/2/issue', () => {
+  // This test confirms the endpoint exists and returns 201, but doesn't send a body or check the response body structure.
+  // It might pass even if the controller logic is incomplete.
+  it('should respond with 201', async () => {
+    const response = await request(app).post('/rest/api/2/issue');
+    expect(response.statusCode).toBe(201);
+  });
+
+  // This new test simulates a happy path request by sending a valid body
+  // and asserts both the 201 status and the expected structure of the response body.
+  // It is expected to fail initially because the current controller returns
+  // a different body structure ({ message: ... }) than expected ({ id, key, self }).
+  it('should respond with 201 and return issue details on successful creation', async () => {
+    const newIssue = {
+      summary: 'Test Issue Summary',
+      description: 'This is a test issue description.',
+      projectKey: 'TEST',
+      issueType: 'Bug',
+      // Add other fields as per API contract if known
+    };
+
+    const response = await request(app)
+      .post('/rest/api/2/issue')
+      .send(newIssue)
+      .set('Accept', 'application/json'); // Indicate we expect JSON response
+
+    // Assert the status code is 201 Created
+    expect(response.statusCode).toBe(201);
+
+    // Assert the response body structure matches the expected successful creation response
+    // This check makes the test fail with the current placeholder controller implementation
+    expect(response.body).toBeDefined();
+    expect(response.body).toHaveProperty('id'); // Expected JIRA-like response properties
+    expect(response.body).toHaveProperty('key');
+    expect(response.body).toHaveProperty('self');
+    // Further checks could be added, e.g., expect(typeof response.body.id).toBe('string')
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,11 @@
 import express, { Express, Request, Response } from 'express';
+import issueRoutes from './api/routes/issueRoutes'; // Import issue routes
 
 const app: Express = express();
 const port: number = 3000;
+
+// Mount issue routes
+app.use('/', issueRoutes); // Use the issue routes
 
 app.get('/', (req: Request, res: Response) => {
   res.send('Hello World!');


### PR DESCRIPTION
Implement POST /rest/api/2/issue route and create a placeholder controller function.

This commit defines the `/rest/api/2/issue` route in `src/api/routes/issueRoutes.ts` and links it to the `createIssue` handler function in `src/api/controllers/issueController.ts`.

The `createIssue` function currently contains placeholder logic that returns a mock successful response structure.

Tests for the new route have been added to `src/app.test.ts` and are passing, validating the route setup and the structure of the mock response returned by the controller.

Includes Swagger documentation annotations for the new route.