### PR TITLE
ATM-1431: Define all TypeORM Database Entities

### DIFF
--- a/src/db/entities/attachment.entity.ts
+++ b/src/db/entities/attachment.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { Issue } from './issue.entity';
+import { User } from './user.entity';
+
+@Entity('attachment')
+export class Attachment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  filename: string;
+
+  @Column({ unique: true })
+  storedFilename: string;
+
+  @Column()
+  mimetype: string;
+
+  @Column()
+  size: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @ManyToOne(() => Issue, (issue) => issue.attachments)
+  @JoinColumn({ name: 'issueId' })
+  issue: Issue;
+
+  @ManyToOne(() => User, (user) => user.attachments)
+  @JoinColumn({ name: 'authorId' })
+  author: User;
+}

--- a/src/db/entities/issue.entity.ts
+++ b/src/db/entities/issue.entity.ts
@@ -1,0 +1,72 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    OneToMany,
+    CreateDateColumn,
+    UpdateDateColumn,
+    JoinColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+import { Attachment } from './attachment.entity';
+import { IssueLink } from './issue_link.entity';
+
+@Entity('issue')
+export class Issue {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ unique: true })
+    issueKey: string;
+
+    @Column()
+    summary: string;
+
+    @Column({ type: 'text' })
+    description: string;
+
+    @Column()
+    statusId: number;
+
+    @Column()
+    issueTypeId: number;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+
+    @ManyToOne(() => User, (user) => user.assignedIssues)
+    @JoinColumn({ name: 'assigneeId' })
+    assignee: User;
+
+    @ManyToOne(() => User, (user) => user.reportedIssues)
+    @JoinColumn({ name: 'reporterId' })
+    reporter: User;
+
+    @ManyToOne(() => Issue, (issue) => issue.children, {
+        nullable: true,
+    })
+    @JoinColumn({ name: 'parentId' })
+    parent?: Issue;
+
+    @ManyToOne(() => Issue, {
+        nullable: true,
+    })
+    @JoinColumn({ name: 'epicId' })
+    epic?: Issue;
+
+    @OneToMany(() => Issue, (issue) => issue.parent)
+    children: Issue[];
+
+    @OneToMany(() => Attachment, (attachment) => attachment.issue)
+    attachments: Attachment[];
+
+    @OneToMany(() => IssueLink, (issueLink) => issueLink.inwardIssue)
+    inwardLinks: IssueLink[];
+
+    @OneToMany(() => IssueLink, (issueLink) => issueLink.outwardIssue)
+    outwardLinks: IssueLink[];
+}

--- a/src/db/entities/issue_link.entity.ts
+++ b/src/db/entities/issue_link.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from "typeorm";
+import { Issue } from "./issue.entity";
+
+@Entity('issue_link')
+export class IssueLink {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    linkTypeId: number;
+
+    @ManyToOne(() => Issue, issue => issue.inwardLinks, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'inwardIssueId' })
+    inwardIssue: Issue;
+
+    @ManyToOne(() => Issue, issue => issue.outwardLinks)
+    @JoinColumn({ name: 'outwardIssueId' })
+    outwardIssue: Issue;
+}

--- a/src/db/entities/user.entity.ts
+++ b/src/db/entities/user.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, PrimaryGeneratedColumn, Column, Unique, OneToMany } from 'typeorm';
+import { Issue } from './issue.entity';
+import { Attachment } from './attachment.entity';
+
+@Entity()
+@Unique(['userKey'])
+@Unique(['emailAddress'])
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    userKey: string;
+
+    @Column()
+    displayName: string;
+
+    @Column()
+    emailAddress: string;
+
+    @OneToMany(() => Issue, (issue) => issue.assignee)
+    assignedIssues: Issue[];
+
+    @OneToMany(() => Issue, (issue) => issue.reporter)
+    reportedIssues: Issue[];
+
+    @OneToMany(() => Attachment, (attachment) => attachment.author)
+    attachments: Attachment[];
+}


### PR DESCRIPTION
Implemented TypeORM entity classes for `User`, `Issue`, `Attachment`, and `IssueLink` as per the task requirements. Ensured all columns, data types, and relationships (including foreign keys and self-referencing relationships) are correctly defined. Resolved a previous conflict in the `Issue` entity's `epic` relationship to ensure proper schema generation. The entity definitions are now ready for database migration.