### PR TITLE
ATM-1433: Set up Jest Testing Framework and Implement `db:seed` Script

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+  setupFiles: ['<rootDir>/jest.setup.ts'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,2 @@
+process.env.NODE_ENV = 'test';
+console.log("Setting NODE_ENV to test in jest.setup.ts");

--- a/package.json
+++ b/package.json
@@ -5,13 +5,16 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "test:unit": "jest --testPathPattern=tests/unit",
+    "test:integration": "jest --testPathPattern=tests/integration",
     "build": "tsc",
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
     "start": "node dist/server.js",
     "typeorm": "typeorm-ts-node-commonjs",
-    "db:generate": "cross-env TS_NODE_PROJECT=./src/db/tsconfig.json npm run typeorm -- migration:generate src/db/migrations/InitialSchema -d src/db/data-source.ts",
+    "db:migration:generate": "cross-env TS_NODE_PROJECT=./src/db/tsconfig.json npm run typeorm -- migration:generate src/db/migrations/InitialSchema -d src/db/data-source.ts",
     "db:migrate": "cross-env TS_NODE_PROJECT=./src/db/tsconfig.json npm run typeorm -- migration:run -d src/db/data-source.ts",
-    "db:drop": "rm -f src/db/agent-task-manager.sqlite"
+    "db:drop": "rm -f src/db/agent-task-manager.sqlite",
+    "db:seed": "ts-node src/db/seed.ts"
   },
   "repository": {
     "type": "git",

--- a/src/db/migrations/1749667545339-InitialSchema.ts
+++ b/src/db/migrations/1749667545339-InitialSchema.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class InitialSchema1749667545339 implements MigrationInterface {
+    name = 'InitialSchema1749667545339'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "userKey" varchar NOT NULL, "displayName" varchar NOT NULL, "emailAddress" varchar NOT NULL, CONSTRAINT "UQ_eea9ba2f6e1bb8cb89c4e672f62" UNIQUE ("emailAddress"), CONSTRAINT "UQ_f895fe808c3662976bee0b530ec" UNIQUE ("userKey"))`);
+        await queryRunner.query(`CREATE TABLE "issue_link" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "linkTypeId" integer NOT NULL, "inwardIssueId" integer, "outwardIssueId" integer)`);
+        await queryRunner.query(`CREATE TABLE "issue" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "issueKey" varchar NOT NULL, "summary" varchar NOT NULL, "description" text NOT NULL, "statusId" integer NOT NULL, "issueTypeId" integer NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "assigneeId" integer, "reporterId" integer, "parentId" integer, "epicId" integer, CONSTRAINT "UQ_921c1decd44af970d44784d866e" UNIQUE ("issueKey"))`);
+        await queryRunner.query(`CREATE TABLE "attachment" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "filename" varchar NOT NULL, "storedFilename" varchar NOT NULL, "mimetype" varchar NOT NULL, "size" integer NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "issueId" integer, "authorId" integer, CONSTRAINT "UQ_eb96784ad7f49730d6e908950c7" UNIQUE ("storedFilename"))`);
+        await queryRunner.query(`CREATE TABLE "temporary_issue_link" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "linkTypeId" integer NOT NULL, "inwardIssueId" integer, "outwardIssueId" integer, CONSTRAINT "FK_fa367ca095dedd273592483e750" FOREIGN KEY ("inwardIssueId") REFERENCES "issue" ("id") ON DELETE CASCADE ON UPDATE NO ACTION, CONSTRAINT "FK_af760f319dc6b9299c37bff72bb" FOREIGN KEY ("outwardIssueId") REFERENCES "issue" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`);
+        await queryRunner.query(`INSERT INTO "temporary_issue_link"("id", "linkTypeId", "inwardIssueId", "outwardIssueId") SELECT "id", "linkTypeId", "inwardIssueId", "outwardIssueId" FROM "issue_link"`);
+        await queryRunner.query(`DROP TABLE "issue_link"`);
+        await queryRunner.query(`ALTER TABLE "temporary_issue_link" RENAME TO "issue_link"`);
+        await queryRunner.query(`CREATE TABLE "temporary_issue" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "issueKey" varchar NOT NULL, "summary" varchar NOT NULL, "description" text NOT NULL, "statusId" integer NOT NULL, "issueTypeId" integer NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "assigneeId" integer, "reporterId" integer, "parentId" integer, "epicId" integer, CONSTRAINT "UQ_921c1decd44af970d44784d866e" UNIQUE ("issueKey"), CONSTRAINT "FK_d92e4c455673ad050d998bb2c56" FOREIGN KEY ("assigneeId") REFERENCES "user" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT "FK_668ba5ace621b4afbb808f2af48" FOREIGN KEY ("reporterId") REFERENCES "user" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT "FK_5b80b4f6d142f063d4a948155b0" FOREIGN KEY ("parentId") REFERENCES "issue" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT "FK_e7f512a846f5931ca88c5e04f56" FOREIGN KEY ("epicId") REFERENCES "issue" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`);
+        await queryRunner.query(`INSERT INTO "temporary_issue"("id", "issueKey", "summary", "description", "statusId", "issueTypeId", "createdAt", "updatedAt", "assigneeId", "reporterId", "parentId", "epicId") SELECT "id", "issueKey", "summary", "description", "statusId", "issueTypeId", "createdAt", "updatedAt", "assigneeId", "reporterId", "parentId", "epicId" FROM "issue"`);
+        await queryRunner.query(`DROP TABLE "issue"`);
+        await queryRunner.query(`ALTER TABLE "temporary_issue" RENAME TO "issue"`);
+        await queryRunner.query(`CREATE TABLE "temporary_attachment" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "filename" varchar NOT NULL, "storedFilename" varchar NOT NULL, "mimetype" varchar NOT NULL, "size" integer NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "issueId" integer, "authorId" integer, CONSTRAINT "UQ_eb96784ad7f49730d6e908950c7" UNIQUE ("storedFilename"), CONSTRAINT "FK_54f51431f696f4d3b8436475e88" FOREIGN KEY ("issueId") REFERENCES "issue" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT "FK_c8cacbfb04fdb38644032d02aa5" FOREIGN KEY ("authorId") REFERENCES "user" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`);
+        await queryRunner.query(`INSERT INTO "temporary_attachment"("id", "filename", "storedFilename", "mimetype", "size", "createdAt", "issueId", "authorId") SELECT "id", "filename", "storedFilename", "mimetype", "size", "createdAt", "issueId", "authorId" FROM "attachment"`);
+        await queryRunner.query(`DROP TABLE "attachment"`);
+        await queryRunner.query(`ALTER TABLE "temporary_attachment" RENAME TO "attachment"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "attachment" RENAME TO "temporary_attachment"`);
+        await queryRunner.query(`CREATE TABLE "attachment" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "filename" varchar NOT NULL, "storedFilename" varchar NOT NULL, "mimetype" varchar NOT NULL, "size" integer NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "issueId" integer, "authorId" integer, CONSTRAINT "UQ_eb96784ad7f49730d6e908950c7" UNIQUE ("storedFilename"))`);
+        await queryRunner.query(`INSERT INTO "attachment"("id", "filename", "storedFilename", "mimetype", "size", "createdAt", "issueId", "authorId") SELECT "id", "filename", "storedFilename", "mimetype", "size", "createdAt", "issueId", "authorId" FROM "temporary_attachment"`);
+        await queryRunner.query(`DROP TABLE "temporary_attachment"`);
+        await queryRunner.query(`ALTER TABLE "issue" RENAME TO "temporary_issue"`);
+        await queryRunner.query(`CREATE TABLE "issue" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "issueKey" varchar NOT NULL, "summary" varchar NOT NULL, "description" text NOT NULL, "statusId" integer NOT NULL, "issueTypeId" integer NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "assigneeId" integer, "reporterId" integer, "parentId" integer, "epicId" integer, CONSTRAINT "UQ_921c1decd44af970d44784d866e" UNIQUE ("issueKey"))`);
+        await queryRunner.query(`INSERT INTO "issue"("id", "issueKey", "summary", "description", "statusId", "issueTypeId", "createdAt", "updatedAt", "assigneeId", "reporterId", "parentId", "epicId") SELECT "id", "issueKey", "summary", "description", "statusId", "issueTypeId", "createdAt", "updatedAt", "assigneeId", "reporterId", "parentId", "epicId" FROM "temporary_issue"`);
+        await queryRunner.query(`DROP TABLE "temporary_issue"`);
+        await queryRunner.query(`ALTER TABLE "issue_link" RENAME TO "temporary_issue_link"`);
+        await queryRunner.query(`CREATE TABLE "issue_link" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "linkTypeId" integer NOT NULL, "inwardIssueId" integer, "outwardIssueId" integer)`);
+        await queryRunner.query(`INSERT INTO "issue_link"("id", "linkTypeId", "inwardIssueId", "outwardIssueId") SELECT "id", "linkTypeId", "inwardIssueId", "outwardIssueId" FROM "temporary_issue_link"`);
+        await queryRunner.query(`DROP TABLE "temporary_issue_link"`);
+        await queryRunner.query(`DROP TABLE "attachment"`);
+        await queryRunner.query(`DROP TABLE "issue"`);
+        await queryRunner.query(`DROP TABLE "issue_link"`);
+        await queryRunner.query(`DROP TABLE "user"`);
+    }
+
+}

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,0 +1,58 @@
+import { AppDataSource } from "./data-source";
+import { User } from "./entities/user.entity";
+import { Issue } from "./entities/issue.entity";
+
+async function seedDatabase() {
+    const dataSource = await AppDataSource.initialize();
+
+    const userRepository = dataSource.getRepository(User);
+    const issueRepository = dataSource.getRepository(Issue);
+
+    // Create sample users
+    let user1: User;
+    const existingUser1 = await userRepository.findOneBy({ userKey: "user-1" });
+    if (!existingUser1) {
+        user1 = userRepository.create({
+            userKey: "user-1",
+            displayName: "John Doe",
+            emailAddress: "john.doe@example.com",
+        });
+        await userRepository.save(user1);
+    } else {
+        user1 = existingUser1;
+    }
+
+    let user2: User;
+    const existingUser2 = await userRepository.findOneBy({ userKey: "user-2" });
+    if (!existingUser2) {
+        user2 = userRepository.create({
+            userKey: "user-2",
+            displayName: "Jane Smith",
+            emailAddress: "jane.smith@example.com",
+        });
+        await userRepository.save(user2);
+    } else {
+        user2 = existingUser2;
+    }
+
+    // Create a sample issue
+    const existingIssue1 = await issueRepository.findOneBy({ issueKey: "issue-1" });
+    if (!existingIssue1) {
+        const issue1 = issueRepository.create({
+            issueKey: "issue-1",
+            summary: "Sample Issue",
+            description: "This is a sample issue.",
+            reporter: user1,
+            statusId: 1,
+            issueTypeId: 1,
+        });
+        await issueRepository.save(issue1);
+    }
+
+    console.log("Database seeded successfully!");
+    await AppDataSource.destroy();
+}
+
+seedDatabase().catch(error => {
+    console.error("Error seeding database:", error);
+});

--- a/src/db/verify_seed.ts
+++ b/src/db/verify_seed.ts
@@ -1,0 +1,41 @@
+import sqlite3 from 'sqlite3';
+
+const dbPath = 'src/db/agent-task-manager.sqlite';
+
+function verifySeed() {
+    const db = new sqlite3.Database(dbPath, (err) => {
+        if (err) {
+            console.error("Error opening database:", err.message);
+            return;
+        }
+        console.log("Connected to the database.");
+
+        db.all("SELECT * FROM user", [], (err, users) => {
+            if (err) {
+                console.error("Error querying users:", err.message);
+                db.close();
+                return;
+            }
+            console.log("Users:", JSON.stringify(users, null, 2));
+
+            db.all("SELECT * FROM issue", [], (err, issues) => {
+                if (err) {
+                    console.error("Error querying issues:", err.message);
+                    db.close();
+                    return;
+                }
+                console.log("Issues:", JSON.stringify(issues, null, 2));
+
+                db.close((err) => {
+                    if (err) {
+                        console.error("Error closing database:", err.message);
+                        return;
+                    }
+                    console.log("Database connection closed.");
+                });
+            });
+        });
+    });
+}
+
+verifySeed();


### PR DESCRIPTION
"feat: Setup Jest testing and database seeding

This commit introduces the Jest testing infrastructure and a database seeding script as per the task requirements.

Key changes include:
- **Jest Configuration**:
- Created `jest.config.ts` in the root directory.
- Configured Jest to use `ts-jest` preset, `node` test environment, and `testMatch` patterns for `tests/` directory.
- Added `jest.setup.ts` to automatically set `process.env.NODE_ENV = 'test'` for tests.
- **NPM Test Scripts**:
- Updated `package.json` with `test`, `test:unit`, and `test:integration` scripts.
- **Database Seeding**:
- Created `src/db/seed.ts` to populate the development database with sample users and issues using TypeORM entity repositories.
- Added `db:seed` npm script to `package.json`.
- Included `src/db/verify_seed.ts` for manual verification of seeded data (additional helper script).

These changes ensure a consistent development setup and a robust testing environment."