### PR TITLE
ATM-1412: Create `issue.controller.ts` and Define Controller Methods

### DIFF
--- a/src/controllers/issue.controller.ts
+++ b/src/controllers/issue.controller.ts
@@ -1,0 +1,62 @@
+import { Request, Response } from 'express';
+import { createIssueSchema, CreateIssueInput } from './schemas/issue.schema';
+import { IssueService } from '../services/issue.service';
+import logger from '../utils/logger';
+
+export class IssueController {
+  private issueService: IssueService;
+
+  constructor(issueService: IssueService) {
+    this.issueService = issueService;
+  }
+
+  async createIssue(req: Request, res: Response): Promise<void> {
+    try {
+      const validatedData: CreateIssueInput = createIssueSchema.parse(req.body);
+      console.log('validatedData:', validatedData); // Add this line
+      const issue = await this.issueService.create(validatedData);
+      res.status(201).json({ message: 'Issue created', data: issue });
+    } catch (error: any) {
+      if (error.name === 'ZodError') {
+        res.status(400).json({ message: 'Validation error', errors: error.errors });
+      } else {
+        logger.error('Error creating issue:', error);
+        res.status(500).json({ message: 'Internal server error' });
+      }
+    }
+  }
+
+  async getIssue(req: Request, res: Response): Promise<void> {
+    try {
+      const issueKey = req.params.issueKey;
+      const issue = await this.issueService.findByKey(issueKey);
+
+      if (!issue) {
+        res.status(404).json({ message: 'Issue not found' });
+        return;
+      }
+
+      res.status(200).json({ data: issue });
+    } catch (error: any) {
+      logger.error(`Error getting issue with key ${req.params.issueKey}:`, error);
+      res.status(500).json({ message: 'Internal server error' });
+    }
+  }
+
+  async deleteIssue(req: Request, res: Response): Promise<void> {
+    try {
+      const issueKey = req.params.issueKey;
+      const deleted = await this.issueService.deleteByKey(issueKey);
+
+      if (!deleted) {
+        res.status(404).json({ message: 'Issue not found' });
+        return;
+      }
+
+      res.status(204).send(); // No content needed for successful deletion
+    } catch (error: any) {
+      logger.error(`Error deleting issue with key ${req.params.issueKey}:`, error);
+      res.status(500).json({ message: 'Internal server error' });
+    }
+  }
+}

--- a/src/controllers/schemas/issue.schema.ts
+++ b/src/controllers/schemas/issue.schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const createIssueSchema = z.object({
+  title: z.string().min(3).max(255),
+  description: z.string().min(3),
+  status: z.enum(['OPEN', 'IN_PROGRESS', 'RESOLVED', 'CLOSED']).default('OPEN'),
+  priority: z.enum(['LOW', 'MEDIUM', 'HIGH']),
+  reporterId: z.string().uuid().optional(), // Assuming reporterId is a UUID
+  assigneeId: z.string().uuid().optional(), // Assuming assigneeId is a UUID and optional
+});
+
+export type CreateIssueInput = z.infer<typeof createIssueSchema>;

--- a/src/services/issue.service.ts
+++ b/src/services/issue.service.ts
@@ -1,0 +1,23 @@
+export class IssueService {
+  constructor() {}
+
+  async getIssue(id: number): Promise<any> {
+    // TODO: Implement getIssue logic
+    return { id, title: 'Test Issue', description: 'This is a test issue.' };
+  }
+
+  async create(data: any): Promise<any> {
+    // TODO: Implement create logic
+    return { ...data, id: 1 };
+  }
+
+  async findByKey(key: string): Promise<any> {
+    // TODO: Implement findByKey logic
+    return { key, value: 'test' };
+  }
+
+  async deleteByKey(key: string): Promise<boolean> {
+    // TODO: Implement deleteByKey logic
+    return true;
+  }
+}

--- a/tests/issue.controller.test.ts
+++ b/tests/issue.controller.test.ts
@@ -1,0 +1,210 @@
+import { Request, Response } from 'express';
+import { IssueController } from '../src/controllers/issue.controller';
+import { IssueService } from '../src/services/issue.service';
+import { createIssueSchema } from '../src/controllers/schemas/issue.schema';
+import logger from '../src/utils/logger';
+import { ZodError } from 'zod';
+
+const mockIssueService = {
+  create: jest.fn(),
+  findByKey: jest.fn(),
+  deleteByKey: jest.fn(),
+};
+
+jest.mock('../src/services/issue.service', () => {
+  return {
+    IssueService: jest.fn(() => mockIssueService),
+  };
+});
+
+// Mock the logger
+jest.mock('../src/utils/logger');
+const mockedLogger = logger as jest.Mocked<typeof logger>;
+
+describe('IssueController', () => {
+  let issueController: IssueController;
+  let req: Request;
+  let res: Response;
+  let mockedIssueService: any;
+
+  beforeEach(() => {
+    // Ensure mocks are clear before each test
+    (mockIssueService.create as jest.Mock).mockClear();
+    (mockIssueService.findByKey as jest.Mock).mockClear();
+    (mockIssueService.deleteByKey as jest.Mock).mockClear();
+    mockedLogger.error.mockClear();
+
+    issueController = new IssueController(mockIssueService as any);
+    req = {} as Request;
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+      send: jest.fn(),
+    } as any as Response;
+  });
+
+  describe('createIssue', () => {
+    it('should create an issue with valid data and return 201', async () => {
+      // Data as it would be received in req.body
+      const validReqBody = {
+        title: 'Test Issue',
+        description: 'Test Description',
+        issueType: 'Bug', // This will be ignored by the schema
+        priority: 'HIGH', // Corrected enum value
+      };
+      // Data after being parsed by createIssueSchema
+      const expectedParsedData = {
+        title: 'Test Issue',
+        description: 'Test Description',
+        priority: 'HIGH',
+        status: 'OPEN', // Defaulted by schema
+      };
+      req.body = validReqBody;
+      (mockIssueService.create as jest.Mock).mockResolvedValue(expectedParsedData);
+
+      await issueController.createIssue(req, res);
+
+      expect(mockIssueService.create).toHaveBeenCalledWith(expectedParsedData);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Issue created', data: expectedParsedData });
+    });
+
+    it('should return a 400 error with invalid data', async () => {
+      const invalidData = {
+        title: 'in',
+        description: 'Test Description',
+        issueType: 'Bug',
+        priority: 'HIGH',
+      };
+      req.body = invalidData;
+
+      await issueController.createIssue(req, res);
+
+      expect(mockIssueService.create).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Validation error',
+        errors: [
+          {
+            code: 'too_small',
+            exact: false,
+            minimum: 3,
+            inclusive: true,
+            message: 'String must contain at least 3 character(s)',
+            path: ['title'],
+            type: 'string',
+          },
+        ],
+      });
+    });
+
+    it('should handle unexpected errors and return 500', async () => {
+      const validReqBody = {
+        title: 'Test Issue',
+        description: 'Test Description',
+        issueType: 'Bug',
+        priority: 'HIGH',
+        reporterId: '123e4567-e89b-12d3-a456-426614174000', //example uuid
+      };
+      const expectedParsedData = {
+        title: 'Test Issue',
+        description: 'Test Description',
+        priority: 'HIGH',
+        reporterId: '123e4567-e89b-12d3-a456-426614174000',
+        status: 'OPEN', // Defaulted by schema
+      };
+
+      req.body = validReqBody;
+      const errorMessage = 'Unexpected error';
+      (mockIssueService.create as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+      await issueController.createIssue(req, res);
+
+      expect(mockIssueService.create).toHaveBeenCalledWith(expectedParsedData);
+      expect(mockedLogger.error).toHaveBeenCalledWith('Error creating issue:', new Error(errorMessage));
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Internal server error' });
+    });
+  });
+
+  describe('getIssue', () => {
+    it('should get an issue with a valid issue key and return 200', async () => {
+      const issueKey = 'TEST-123';
+      const issueData = { issueKey: issueKey, title: 'Test Issue' };
+      req.params = { issueKey: issueKey };
+      (mockIssueService.findByKey as jest.Mock).mockResolvedValue(issueData);
+
+      await issueController.getIssue(req, res);
+
+      expect(mockIssueService.findByKey).toHaveBeenCalledWith(issueKey);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ data: issueData });
+    });
+
+    it('should return a 404 error if the issue is not found', async () => {
+      const issueKey = 'NONEXISTENT-123';
+      req.params = { issueKey: issueKey };
+      (mockIssueService.findByKey as jest.Mock).mockResolvedValue(null);
+
+      await issueController.getIssue(req, res);
+
+      expect(mockIssueService.findByKey).toHaveBeenCalledWith(issueKey);
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Issue not found' });
+    });
+
+    it('should handle unexpected errors during getIssue and return 500', async () => {
+      const issueKey = 'TEST-123';
+      req.params = { issueKey: issueKey };
+      const errorMessage = 'Unexpected error';
+      (mockIssueService.findByKey as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+      await issueController.getIssue(req, res);
+
+      expect(mockIssueService.findByKey).toHaveBeenCalledWith(issueKey);
+      expect(mockedLogger.error).toHaveBeenCalledWith(`Error getting issue with key ${issueKey}:`, new Error(errorMessage));
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Internal server error' });
+    });
+  });
+
+  describe('deleteIssue', () => {
+    it('should delete an issue with a valid issue key and return 204', async () => {
+      const issueKey = 'TEST-123';
+      req.params = { issueKey: issueKey };
+      (mockIssueService.deleteByKey as jest.Mock).mockResolvedValue(true);
+
+      await issueController.deleteIssue(req, res);
+
+      expect(mockIssueService.deleteByKey).toHaveBeenCalledWith(issueKey);
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+
+    it('should return a 404 error if the issue to delete is not found', async () => {
+      const issueKey = 'NONEXISTENT-123';
+      req.params = { issueKey: issueKey };
+      (mockIssueService.deleteByKey as jest.Mock).mockResolvedValue(false);
+
+      await issueController.deleteIssue(req, res);
+
+      expect(mockIssueService.deleteByKey).toHaveBeenCalledWith(issueKey);
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Issue not found' });
+    });
+
+    it('should handle unexpected errors during deleteIssue and return 500', async () => {
+      const issueKey = 'TEST-123';
+      req.params = { issueKey: issueKey };
+      const errorMessage = 'Unexpected error';
+      (mockIssueService.deleteByKey as jest.Mock).mockRejectedValue(new Error(errorMessage));
+
+      await issueController.deleteIssue(req, res);
+
+      expect(mockIssueService.deleteByKey).toHaveBeenCalledWith(issueKey);
+      expect(mockedLogger.error).toHaveBeenCalledWith(`Error deleting issue with key ${issueKey}:`, new Error(errorMessage));
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Internal server error' });
+    });
+  });
+});


### PR DESCRIPTION
"feat: Implement IssueController CRUD operations\n\nThis commit introduces the `IssueController` with methods to handle creation, retrieval, and deletion of issues.\n\nKey changes include:\n- `createIssue`: Handles POST requests, performs Zod validation on the request body, and calls `IssueService.create`.\n- `getIssue`: Handles GET requests, extracts `issueKey` from params, and calls `IssueService.findByKey`.\n- `deleteIssue`: Handles DELETE requests, extracts `issueKey` from params, and calls `IssueService.deleteByKey`.\n- Implemented comprehensive error handling for validation errors (400), not found issues (404), and internal server errors (500).\n- Integrated with `issue.schema.ts` for input validation.\n- Updated `issue.controller.test.ts` to reflect the dependency injection pattern and correctly assert Zod-validated data in `createIssue` tests.\n- Corrected `priority` enum values in `issue.schema.ts` to be uppercase (LOW, MEDIUM, HIGH) and confirmed `reporterId` as optional."