### PR TITLE
ATM-1415: Backend: Implement IssueLinkService for managing issue link creation

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -22,6 +22,8 @@ beforeAll(async () => {
   await AppDataSource.runMigrations();
   console.log("Seeding database...");
   await seedDatabase();
+  console.log("Synchronizing database schema...");
+  await AppDataSource.synchronize();
 });
 
 afterAll(async () => {

--- a/src/db/entities/issue_link.entity.ts
+++ b/src/db/entities/issue_link.entity.ts
@@ -13,7 +13,13 @@ export class IssueLink {
     @JoinColumn({ name: 'inwardIssueId' })
     inwardIssue: Issue;
 
+    @Column({ name: 'inwardIssueId' })
+    inwardIssueId: number;
+
     @ManyToOne(() => Issue, issue => issue.outwardLinks)
     @JoinColumn({ name: 'outwardIssueId' })
     outwardIssue: Issue;
+
+    @Column({ name: 'outwardIssueId' })
+    outwardIssueId: number;
 }

--- a/src/services/issue.service.ts
+++ b/src/services/issue.service.ts
@@ -1,5 +1,19 @@
 import { AppDataSource } from '../data-source';
 import { Issue } from '../db/entities/issue.entity';
+
+export class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BadRequestError';
+  }
+}
+
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}
 import { CreateIssueInput } from '../controllers/schemas/issue.schema';
 import { User } from '../db/entities/user.entity';
 

--- a/src/services/issueLink.service.ts
+++ b/src/services/issueLink.service.ts
@@ -1,0 +1,64 @@
+import { Issue } from '../db/entities/issue.entity';
+import { IssueLinkType } from '../config/static-data';
+import { z } from 'zod';
+import { BadRequestError, NotFoundError } from './issue.service';
+import { AppDataSource } from '../data-source';
+
+const issueLinkCreateSchema = z.object({
+  type: z.object({
+    name: z.string(),
+  }),
+  inwardIssue: z.object({
+    key: z.string(),
+  }),
+  outwardIssue: z.object({
+    key: z.string(),
+  }),
+});
+
+type IssueLinkCreateDTO = z.infer<typeof issueLinkCreateSchema>;
+
+export class IssueLinkService {
+  async create(data: IssueLinkCreateDTO) {
+    try {
+      issueLinkCreateSchema.parse(data);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new BadRequestError(error.message);
+      }
+      throw error;
+    }
+
+    if (!(data.type.name in IssueLinkType)) {
+      throw new BadRequestError('Invalid link type.');
+    }
+
+    const issueRepository = AppDataSource.getRepository(Issue);
+
+    const inwardIssue = await issueRepository.findOneBy({ issueKey: data.inwardIssue.key });
+    if (!inwardIssue) {
+      throw new NotFoundError('Inward issue not found.');
+    }
+
+    const outwardIssue = await issueRepository.findOneBy({ issueKey: data.outwardIssue.key });
+    if (!outwardIssue) {
+      throw new NotFoundError('Outward issue not found.');
+    }
+
+    // Persist the IssueLink entity to the database.
+    const issueLinkRepository = AppDataSource.getRepository('IssueLink'); // Assuming 'IssueLink' is the name used in AppDataSource
+    const issueLink = issueLinkRepository.create({
+      linkTypeId: IssueLinkType[data.type.name],
+      inwardIssueId: inwardIssue.id,
+      outwardIssueId: outwardIssue.id,
+    });
+
+    await issueLinkRepository.save(issueLink);
+
+    return {
+      type: { name: data.type.name },
+      inwardIssue,
+      outwardIssue,
+    };
+  }
+}

--- a/tests/issueLink.service.test.ts
+++ b/tests/issueLink.service.test.ts
@@ -1,0 +1,165 @@
+import { IssueLinkService } from '../src/services/issueLink.service';
+import { AppDataSource } from '../src/data-source';
+import { Issue } from '../src/db/entities/issue.entity';
+import { BadRequestError, NotFoundError } from '../src/services/issue.service';
+import { IssueLinkType } from '../src/config/static-data';
+
+beforeAll(async () => {
+  // await AppDataSource.initialize(); // Initialized in global setup
+});
+
+afterAll(async () => {
+  // await AppDataSource.destroy(); // Moved to global teardown
+});
+
+describe('IssueLinkService', () => {
+  let issueLinkService: IssueLinkService;
+
+  beforeEach(() => {
+    issueLinkService = new IssueLinkService();
+  });
+
+  afterEach(async () => {
+    // Clean up the database after each test
+    const issueLinkRepository = AppDataSource.getRepository('IssueLink');
+    const issueRepository = AppDataSource.getRepository(Issue);
+
+    // Remove any existing issue links
+    const inwardIssue = await issueRepository.findOne({ where: { issueKey: 'IN-123' } });
+    const outwardIssue = await issueRepository.findOne({ where: { issueKey: 'OUT-456' } });
+    const existingInwardIssue = await issueRepository.findOne({ where: { issueKey: 'EXISTING-IN' } });
+
+    if (inwardIssue && outwardIssue) {
+      const issueLink = await issueLinkRepository.findOne({
+        where: {
+          inwardIssueId: inwardIssue.id,
+          outwardIssueId: outwardIssue.id,
+        },
+      });
+
+      if (issueLink) {
+        await issueLinkRepository.remove(issueLink);
+      }
+    }
+
+    // Remove any existing issues
+    if (inwardIssue) {
+      await issueRepository.remove(inwardIssue);
+    }
+
+    if (outwardIssue) {
+      await issueRepository.remove(outwardIssue);
+    }
+
+    if (existingInwardIssue) {
+      await issueRepository.remove(existingInwardIssue);
+    }
+  });
+
+  describe('create', () => {
+    it('should successfully create an issue link', async () => {
+      // Mock data
+      const linkTypeName = 'Relates';
+      const inwardIssueKey = 'IN-123';
+      const outwardIssueKey = 'OUT-456';
+
+      // Create mock issues in the database
+      const inwardIssue = new Issue();
+      inwardIssue.issueKey = inwardIssueKey;
+      inwardIssue.title = 'Inward Issue Summary';
+      inwardIssue.description = 'Inward Issue Description'; // Add description
+      inwardIssue.issueTypeId = 1; // Replace with a valid issue type ID
+      inwardIssue.priority = 'Medium';
+      await AppDataSource.getRepository(Issue).save(inwardIssue);
+
+      const outwardIssue = new Issue();
+      outwardIssue.issueKey = outwardIssueKey;
+      outwardIssue.title = 'Outward Issue Summary';
+      outwardIssue.description = 'Outward Issue Description'; // Add description
+      outwardIssue.issueTypeId = 2; // Replace with a valid issue type ID
+      outwardIssue.priority = 'High';
+      await AppDataSource.getRepository(Issue).save(outwardIssue);
+
+      const createData = {
+        type: { name: linkTypeName },
+        inwardIssue: { key: inwardIssueKey },
+        outwardIssue: { key: outwardIssueKey },
+      };
+
+      // Call the create method
+      const result = await issueLinkService.create(createData);
+
+      // Assertions
+      expect(result.type.name).toBe(linkTypeName);
+      expect(result.inwardIssue.issueKey).toBe(inwardIssueKey);
+      expect(result.outwardIssue.issueKey).toBe(outwardIssueKey);
+
+      // Verify that a new record is created in the issue_link table
+      const issueLinkRepository = AppDataSource.getRepository('IssueLink');
+      const newIssueLink = await issueLinkRepository.findOne({
+        where: {
+          inwardIssueId: inwardIssue.id,
+          outwardIssueId: outwardIssue.id,
+          linkTypeId: IssueLinkType[linkTypeName],
+        },
+      });
+      expect(newIssueLink).toBeDefined();
+    });
+
+    it('should throw an error if the link type name is not found in the static map', async () => {
+      const createData = {
+        type: { name: 'InvalidLinkType' },
+        inwardIssue: { key: 'IN-123' },
+        outwardIssue: { key: 'OUT-456' },
+      };
+
+      await expect(issueLinkService.create(createData)).rejects.toThrowError(BadRequestError);
+      await expect(issueLinkService.create(createData)).rejects.toThrow('Invalid link type.');
+    });
+
+    it('should throw an error if either the inward or outward issue key does not correspond to an existing issue', async () => {
+      const linkTypeName = 'Relates';
+      const inwardIssueKey = 'NON-EXISTENT-IN';
+      const outwardIssueKey = 'NON-EXISTENT-OUT';
+
+      const createData = {
+        type: { name: linkTypeName },
+        inwardIssue: { key: inwardIssueKey },
+        outwardIssue: { key: outwardIssueKey },
+      };
+
+      await expect(issueLinkService.create(createData)).rejects.toThrowError(NotFoundError);
+      await expect(issueLinkService.create(createData)).rejects.toThrow('Inward issue not found.');
+
+      const inwardIssue = new Issue();
+      inwardIssue.issueKey = 'EXISTING-IN';
+      inwardIssue.title = 'Inward Issue Summary';
+      inwardIssue.description = 'Inward Issue Description';
+      inwardIssue.issueTypeId = 1; // Replace with a valid issue type ID
+      inwardIssue.priority = 'Medium';
+      await AppDataSource.getRepository(Issue).save(inwardIssue);
+
+      const createData2 = {
+        type: { name: linkTypeName },
+        inwardIssue: { key: 'EXISTING-IN' },
+        outwardIssue: { key: outwardIssueKey },
+      };
+
+      await expect(issueLinkService.create(createData2)).rejects.toThrowError(NotFoundError);
+      await expect(issueLinkService.create(createData2)).rejects.toThrow('Outward issue not found.');
+
+      await AppDataSource.getRepository(Issue).remove(inwardIssue);
+
+    });
+
+    it('should throw an error if the input does not match the zod schema', async () => {
+      const createData = {
+        type: { name: 123 }, // Invalid type
+        inwardIssue: { key: 'IN-123' },
+        outwardIssue: { key: 'OUT-456' },
+      };
+
+      await expect(issueLinkService.create(createData as any)).rejects.toThrowError(BadRequestError);
+    });
+  });
+});


### PR DESCRIPTION
|
Implement IssueLinkService for linking issues.

This commit introduces the core service responsible for linking two issues, adhering to the specified business logic and validation requirements.

Key changes include:
- Creation of `src/services/issueLink.service.ts` with a `create` method.
- Input validation using Zod schema (`issueLinkCreateSchema`).
- Validation of link type names against `IssueLinkType` static data.
- Validation of `inwardIssue` and `outwardIssue` existence using the `Issue` repository.
- Persistence of new `IssueLink` records to the `issue_link` table with correct foreign keys.
- Refactoring `BadRequestError` and `NotFoundError` to `src/services/issue.service.ts` for shared use.
- Updates to `src/db/entities/issue_link.entity.ts` to explicitly define foreign key columns (`inwardIssueId`, `outwardIssueId`), resolving TypeORM mapping issues.
- Addition of `AppDataSource.synchronize()` in `jest.setup.ts` to ensure consistent test database schema.
- Comprehensive unit tests in `tests/issueLink.service.test.ts` covering all success and failure scenarios as per acceptance criteria.